### PR TITLE
Add special characters/cases for obsolete and colloquial terms

### DIFF
--- a/R/process_NSSH_629A.R
+++ b/R/process_NSSH_629A.R
@@ -115,8 +115,9 @@ process_NSSH_629A <- function(outpath = "./inst/extdata") {
       }
 
       # search for obsolete, not preferred
-      if (length(grep("\\(obsolete \u2014 use|\\(not recommended|\\(not preferred", j) > 0)) {
-        obspattern <- '.*obsolete \u2014 use ([A-Za-z, ]+).*|.*\\(not recommended: obsolete\\) Use ([^\\.]*).?$|.*\\(not recommended\\) Use ([^\\.]*).?$|.*\\(not preferred\\) Use ([^\\.]*).?$|.*\\(not preferred.*[Rr]efer to ([^\\.\\)]*).?.*|.*\\(not recommended, use ([^\\.]*)\\).*'
+      if (length(grep("\\(obsolete \u2014 use|\\(not recommended|\\(not preferred|; not preferred", j) > 0)) {
+        obspattern <- '.*obsolete \u2014 use ([A-Za-z, ]+).*|.*\\(not recommended: obsolete\\) Use ([^\\.]*).?$|.*\\(not recommended\\) Use ([^\\.]*).?$|.*\\(not preferred\\) Use ([^\\.]*).?$|.*[\\(;\\u2013] ?not preferred.*[Rr]efer to ([^\\.\\)]*).?.*|.*\\(not recommended, use ([^\\.]*)\\).*'
+
         obsolete <- grepl("obsolete", j)
         newterms <- trimws(strsplit(gsub(obspattern, "\\1\\2\\3\\4\\5\\6", j), ",|, or")[[1]])
         if (length(grep(obspattern, j)) == 0)
@@ -125,7 +126,7 @@ process_NSSH_629A <- function(outpath = "./inst/extdata") {
 
       # search for colloquial
       if (length(grep("\\(colloquial:", j) > 0)) {
-        coldesc <- trimws(strsplit(gsub('.*colloquial:([A-Za-z, ]+)\\).*', "\\1", j), ",|, or")[[1]])
+        coldesc <- trimws(strsplit(gsub('.*colloquial:([A-Za-z\\., ]+)[\\);\\u2013].*', "\\1", j), ",|, or")[[1]])
       } else coldesc <- character(0)
 
       h <- trimws(strsplit(gsub("\\(\\d+\\) ([^\\(\\)]*).[\u2014](.*)", "\\1::::\\2", j), "::::")[[1]])

--- a/inst/extdata/NSSH/629/GDS-glossary-G.json
+++ b/inst/extdata/NSSH/629/GDS-glossary-G.json
@@ -604,9 +604,9 @@
       "compare": null,
       "sources": "HP",
       "colloquial": true,
-      "colloquloc": ["(467) gulch.—(colloquial: western United States; not preferred – refer to ravine) A small stream channel", "narrow and steep-sided in cross section", "and larger than a gully", "cut in unconsolidated materials. General synonym – ravine."],
-      "obsolete": false,
-      "preferred": []
+      "colloquloc": "western United States",
+      "obsolete": true,
+      "preferred": "ravine"
     }
   ],
   [
@@ -652,7 +652,7 @@
       "compare": null,
       "sources": null,
       "colloquial": true,
-      "colloquloc": ["(471) gut [valley].—(colloquial: U.S. Virgin Islands", "Caribbean Basin) A gully", "ravine", "small valley", "narrow passage on land."],
+      "colloquloc": ["U.S. Virgin Islands", "Caribbean Basin"],
       "obsolete": false,
       "preferred": []
     }

--- a/inst/extdata/NSSH/629/GDS-glossary-I.json
+++ b/inst/extdata/NSSH/629/GDS-glossary-I.json
@@ -374,7 +374,7 @@
       "compare": null,
       "sources": "SW",
       "colloquial": true,
-      "colloquloc": ["(538) interstream divide.—(colloquial: esp. southeastern United States). Broad interstream divide – A wide", "relatively level area between incised drainageways; a broad", "nearly level “summit” or interfluve."],
+      "colloquloc": "esp. southeastern United States",
       "obsolete": false,
       "preferred": []
     }

--- a/inst/extdata/NSSH/629/GDS-glossary-P.json
+++ b/inst/extdata/NSSH/629/GDS-glossary-P.json
@@ -126,9 +126,9 @@
       "compare": null,
       "sources": ["GG", "SW"],
       "colloquial": true,
-      "colloquloc": ["(738) park.—(colloquial: Rocky Mountains", "United States; not preferred – refer to valley", "intermontane basin).—An ecological term for a grassy or shrubby", "wide", "open valley lying at high elevation and confined between forested mountain slopes", "as in a high meadow; sometimes marshy."],
-      "obsolete": false,
-      "preferred": []
+      "colloquloc": ["Rocky Mountains", "United States"],
+      "obsolete": true,
+      "preferred": ["valley", "intermontane basin"]
     },
     {
       "term": "park",
@@ -136,9 +136,9 @@
       "compare": null,
       "sources": ["GG", "SW"],
       "colloquial": true,
-      "colloquloc": ["(738) park.—(colloquial: Rocky Mountains", "United States; not preferred – refer to valley", "intermontane basin).—(refer to intermontane basin) A level valley between mountain ranges."],
-      "obsolete": false,
-      "preferred": []
+      "colloquloc": ["Rocky Mountains", "United States"],
+      "obsolete": true,
+      "preferred": "intermontane basin"
     }
   ],
   [


### PR DESCRIPTION
 - Fixes: gulch, gulf, interstream divide, park

Will close #28 