### PR TITLE
create_OSD: several Typical Pedon parsing patches

### DIFF
--- a/R/create_OSD.R
+++ b/R/create_OSD.R
@@ -230,7 +230,7 @@ validateOSD <- function(logfile, filepath) {
   # TODO: abstract and generalize these into rules
 
   headerpatterns <- c("TAXONOMIC CLASS",
-                      "TY[PIC]+(AL|FYING) PEDON|SOIL PROFILE|Typical [Pp]edon",
+                      "TY[PIC]+(AL|FYING)? ?PEDON|SOIL PROFILE|Typical ?[Pp]edon|REFERENCE PEDON",
                       "TYPE LOCATION",
                       "RANGE IN CHARACTERISTICS|RANGE OF CHARACTERISTICS|RANGE OF INDIVIDUAL HORIZONS",
                       "COMPETING SERIES",

--- a/inst/extdata/OSD/A/ALAPAI.json
+++ b/inst/extdata/OSD/A/ALAPAI.json
@@ -186,6 +186,19 @@
         "pH": 6.3,
         "pH_class": "slightly acid",
         "narrative": "Bw7--178 to 188 centimeters (70 to 74 inches); 25 percent dark reddish brown (2.5YR 3/4), 25 percent brown (7.5YR 4/4), 25 percent strong brown (7.5YR 4/6), and 25 percent yellowish brown (10YR 5/6) hydrous silty clay loam; moderate medium, fine, and very fine subangular blocky structure; friable, slightly sticky, moderately plastic; strongly smeary; few very fine roots; many very fine and fine tubular, common medium interstitial pores; common, thick gelatin-like coatings on surfaces of peds; slightly acid (pH 6.3)."
+      },
+      {
+        "name": "Bw4",
+        "top": 127,
+        "moist_hue": "5YR",
+        "moist_value": 3,
+        "moist_chroma": 4,
+        "texture_class": "silty clay loam",
+        "pH": 6.8,
+        "pH_class": "neutral",
+        "distinctness": "abrupt",
+        "topography": "smooth",
+        "narrative": "Bw4--127 to145 centimeters (50 to 57 inches); 50 percent dark reddish brown (5YR 3/4) and 50 percent dark brown (7.5YR 3/4) hydrous silty clay loam; moderate medium subangular blocky structure parting to moderate fine and very fine subangular blocky structure; friable, slightly sticky and moderately plastic; moderately smeary; few very fine roots; many very fine and fine tubular, common medium and few coarse interstitial pores; common, thin gelatin-like coatings on surfaces of peds; common, gray (7.5YR 5/1) and black (10YR 2/1) specks; 10 percent firm to very firm, dark reddish brown (2.5YR 3/4) 1 to 4 millimeters cinders; neutral (pH 6.8); abrupt smooth boundary. (15 to 18 centimeters {6 to 7 inches} thick)"
       }
     ]
   ]

--- a/inst/extdata/OSD/A/ALMAC.json
+++ b/inst/extdata/OSD/A/ALMAC.json
@@ -169,7 +169,6 @@
       },
       {
         "name": "Oi",
-        "top": 6,
         "narrative": "Oi--2.5 inches to 0;  undecomposed and partially decomposed forest litter."
       }
     ]

--- a/inst/extdata/OSD/A/ALMAVILLE.json
+++ b/inst/extdata/OSD/A/ALMAVILLE.json
@@ -67,8 +67,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 13,
+        "name": "Ap",
+        "top": 0,
+        "bottom": 13,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 1,
@@ -79,8 +80,9 @@
         "narrative": "Ap--0-5 inches, dark gray (10YR 4/1) silt loam; weak fine granular structure; very friable; many fine roots; common fine very dark grayish brown (10YR 3/2) manganese concretions; few fine distinct gray (10YR 6/1) iron depletions; slightly acid; abrupt smooth boundary.  (3 to 10 inches thick)"
       },
       {
-        "name": "5",
-        "top": 20,
+        "name": "Eg",
+        "top": 13,
+        "bottom": 20,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 1,
@@ -91,8 +93,9 @@
         "narrative": "Eg--5-8 inches, gray (10YR 6/1) silt loam; weak fine and medium platy structure; friable; common fine roots; common fine very dark grayish brown (10YR 3/2) manganese concretions; approximately 2 percent fragments of chert; strongly acid; clear wavy boundary.  (0 to 8 inches thick)"
       },
       {
-        "name": "8",
-        "top": 64,
+        "name": "Bg1",
+        "top": 20,
+        "bottom": 64,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 1,
@@ -103,8 +106,9 @@
         "narrative": "Bg1--8-25 inches, gray (10YR 6/1) silt loam; weak fine subangular blocky structure; friable; few fine roots; few fine very dark grayish brown (10YR3/2) manganese concretions; common medium prominent light olive brown (2.5Y 5/6) masses as iron accumulations;  approximately 2 percent fragments of chert; strongly acid; clear wavy boundary.  (10 to 26 inches thick)"
       },
       {
-        "name": "25",
-        "top": 71,
+        "name": "Bg2",
+        "top": 64,
+        "bottom": 71,
         "moist_hue": "2.5Y",
         "moist_value": 6,
         "moist_chroma": 2,
@@ -115,8 +119,9 @@
         "narrative": "Bg2--25-28 inches, light brownish gray (2.5Y 6/2) siltloam; weak medium platy structure; firm; few fine roots; common medium very dark grayish brown (10YR 3/2) manganese concretions; common fine distinct light olive brown (2.5Y 5/6) masses as iron accumulations; brittle in 40 percent of the mass; strongly acid; clear irregular boundary.  (0 to 10 inches thick)"
       },
       {
-        "name": "28",
-        "top": 102,
+        "name": "Btx1",
+        "top": 71,
+        "bottom": 102,
         "moist_hue": "2.5Y",
         "moist_value": 6,
         "moist_chroma": 2,
@@ -127,8 +132,9 @@
         "narrative": "Btx1--28-40 inches, light brownish gray (2.5Y 6/2) silty clay loam; weak very coarse prismatic structure parting to weak medium platy and weak medium angular blocky; few very fine roots along vertical seams; common fine discontinuous tubular pores; common fine prominent gray (10YR 5/1) clay films on faces of prisms and along vertical seams; common medium and coarse light brownish gray (10YR 6/2) silt and silt loam coatings on prism faces and as vertical seams; common medium and coarse black (10YR 2.5/1) and very dark grayish brown (10YR 3/2) manganese concretions; few medium distinct light olive brown (2.5Y 5/6) masses as iron accumulations; brittle in 80 percent of the mass; approximately 2 percent fragments of chert; moderately acid; gradual wavy boundary.  (8 to 30 inches thick)"
       },
       {
-        "name": "40",
-        "top": 183,
+        "name": "Btx2",
+        "top": 102,
+        "bottom": 183,
         "moist_hue": "N",
         "moist_value": 6,
         "moist_chroma": 0,

--- a/inst/extdata/OSD/A/AMBIA.json
+++ b/inst/extdata/OSD/A/AMBIA.json
@@ -65,16 +65,18 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 18,
+        "name": "A11",
+        "top": 0,
+        "bottom": 18,
         "moist_hue": "10YR",
         "moist_value": 3,
         "moist_chroma": 2,
         "narrative": "A11     --  0-7 inches, very dark grayish brown (10YR 3/2)"
       },
       {
-        "name": "7",
-        "top": 41,
+        "name": "A12g",
+        "top": 18,
+        "bottom": 41,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 2,
@@ -82,8 +84,9 @@
         "narrative": "A12g    --  7-16 inches, grayish brown (10YR 5/2) clay loam;"
       },
       {
-        "name": "16",
-        "top": 84,
+        "name": "IIA11bg",
+        "top": 41,
+        "bottom": 84,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 2,
@@ -91,8 +94,9 @@
         "narrative": "IIA11bg --  16-33 inches, dark grayish brown (10YR 4/2) clay; common medium distinct dark yellowish brown (10YR 4/4) mottles and common medium faint gray (10YR 5/1) mottles; moderate medium subangular blocky structure; extremely hard, very firm, plastic;"
       },
       {
-        "name": "33",
-        "top": 175,
+        "name": "IIA12bg",
+        "top": 84,
+        "bottom": 175,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 1,
@@ -100,8 +104,9 @@
         "narrative": "IIA12bg --  33-69 inches, dark gray (10YR 4/1) clay; common medium faint dark grayish brown (10YR 4/2) mottles and few fine distinct dark brown and dark yellowish brown mottles; weak coarse blocky structure parting to moderate medium subangular blocky structure; extremely hard, very firm, plastic; few slickensides;"
       },
       {
-        "name": "69",
-        "top": 244,
+        "name": "IIIA1bg",
+        "top": 175,
+        "bottom": 244,
         "moist_hue": "10YR",
         "moist_value": 3,
         "moist_chroma": 1,

--- a/inst/extdata/OSD/A/ANTERO.json
+++ b/inst/extdata/OSD/A/ANTERO.json
@@ -113,8 +113,9 @@
         "narrative": "C2g--36 to 60 inches; grayish brown (10YR 5/2) sandy loam, dark grayish brown (10YR 4/2) moist; many medium distinct mottles, yellowish brown (10YR 5/6) and gray (5Y 6/1) moist; massive; slightly hard, very friable; calcareous; moderately alkaline."
       },
       {
-        "name": "0",
-        "top": 18,
+        "name": "A1g",
+        "top": 0,
+        "bottom": 18,
         "dry_hue": "10YR",
         "dry_value": 5,
         "dry_chroma": 2,

--- a/inst/extdata/OSD/B/BADGER.json
+++ b/inst/extdata/OSD/B/BADGER.json
@@ -145,6 +145,19 @@
         "distinctness": "clear",
         "topography": "wavy",
         "narrative": "Cg1--117 to 140 centimeters (46 to 55 inches); grayish brown (2.5Y 5/2) silty clay loam, light brownish gray (2.5Y 6/2) dry; massive; friable, slightly sticky and slightly plastic; many medium prominent brownish yellow (10YR 6/6) redoximorphic concentrations and many medium distinct light gray (10YR 7/1) redoximorphic depletions; slightly alkaline; clear wavy boundary."
+      },
+      {
+        "name": "2Cg2",
+        "top": 140,
+        "dry_hue": "2.5Y",
+        "dry_value": 6,
+        "dry_chroma": 2,
+        "moist_hue": "2.5Y",
+        "moist_value": 5,
+        "moist_chroma": 2,
+        "texture_class": "clay loam",
+        "pH_class": "slightly alkaline",
+        "narrative": "2Cg2--140 to152 centimeters (55 to 60 inches); grayish brown (2.5Y 5/2) clay loam, light brownish gray (2.5Y 6/2) dry; massive; friable, slightly sticky and slightly plastic; common fine dark accumulations (iron and manganese oxides); few fine accumulations of carbonate; many medium prominent brownish yellow (10YR 6/6) redoximorphic concentrations and many medium distinct light gray (10YR 7/1) redoximorphic depletions; strongly effervescent; slightly alkaline."
       }
     ]
   ]

--- a/inst/extdata/OSD/B/BAGGER.json
+++ b/inst/extdata/OSD/B/BAGGER.json
@@ -10,8 +10,8 @@
     "content": "TAXONOMIC CLASS: Coarse-loamy, mixed, active, nonacid, thermic Alfic Xerarents"
   },
   "TYPICAL PEDON": {
-    "section": "TYPICAL PEDON",
-    "content": null
+    "section": "REFERENCE PEDON",
+    "content": "REFERENCE PEDON:  Bagger sandy loam on a nearby level slope of less than 1 percent in a sudan grass field at 50 feet elevation. (Colors are for dry soil unless otherwise stated.  When described on November 6, 1976, the soil was moist throughout.)\nAp--0 to 9 inches; mixed pale brown and yellowish brown (10YR 6/3, 5/4) sandy loam, dark yellowish brown (10YR 4/4) moist; massive; hard, friable, slightly sticky and slightly plastic; common very fine, fine and medium roots; many very fine and fine interstitial pores; about 10 percent by volume 2 to 35 mm hardpan fragments which can be broken by hand; hardpan fragments have same color as soil matrix; neutral (pH 7.2); gradual smooth boundary. (4 to 12 inches thick)\n2C1--9 to 16 inches; mixed light gray, white and brown (2.5Y 7/2, 8/2; 7.5Y 5/4) light sandy clay loam, grayish brown and brown (2.5Y 5/2; 7.5YR 4/4) moist; massive; hard, friable, sticky and slightly plastic; few very fine roots; common very fine and fine interstitial pores; common thin silica colloids bridging sand grains; about 10 percent by volume 2 to 35 mm hardpan fragments which can be broken by hand; hardpan fragments have same color as matrix; fragments of Bt (argillic) dark brown (7.5YR 4/4) moist clay and clay loam; about 5 percent by volume black (N 4/ ) Fe-Mn soft concretion ranging up to 5 mm in diameter; slightly calcareous with lime segregated in few fine filaments, moderately alkaline (pH 8.0); clear wavy boundary.  (0 to 20 inches thick)\n3C2--16 to 30 inches; mixed pale brown and brown (10YR 6/3, 7.5YR 5/4) loamy sand and sandy loam, dark brown (10YR 4/3, 7.5YR 4/4) moist; massive; hard, friable, nonsticky and slightly sticky and nonplastic and slightly plastic; few very fine roots; common very fine interstitial pores; about 3 percent by volume Bt (argillic) fragments having many very fine tubular pores and common thin clay films lining the tubular pores and common thin silica colloids bridging sand grains; in small pockets 20 percent by volume 2 to 5 mm gravels encased by loamy sand fill; about 25 percent by volume 5 to 35 mm hardpan fragments within small pockets in the lower 2/3 of the horizon having the same color as the horizon matrix; few black (N 2/) 2 to 5 mm Fe-Mn flakes; mildly alkaline (pH 7.5); abrupt smooth boundary.  (0 to 20 inches thick)\n4Ab--30 to 35 inches; grayish brown (10YR 5/2) loam, very dark grayish brown (10YR 3/2) moist; common fine distinct yellowish red (5YR 5/6) mottles, dark reddish brown (5YR 3/4) moist; massive; hard, friable, slightly sticky and slightly plastic; common very fine roots; common very fine tubular and interstitial pores; 1/4 inch organic residue at top of horizon, few black (N 2/) 1 to 5 mm Fe-Mn concretions; medium acid (pH 6.0); gradual wavy boundary.  (0 to 10 inches thick)\n4C3--35 to 49 inches; brown (10YR 5/3) loam, dark brown (10YR 3/3) moist; massive; hard, friable, slightly sticky and slightly plastic; few very fine roots; common very fine, fine and medium tubular and common very fine and fine interstitial pores; few black (N 2/) 1 to 5 mm Fe-Mn concretions; mildly alkaline (pH 7.5); clear wavy boundary. (0 to 20 inches thick)\n4Cq--49 to 60 inches; light yellowish brown (10YR 6/4) fine sandy loam, dark yellowish brown (10YR 4/4) moist; massive; very hard, firm, slightly sticky and slightly plastic; no roots; few very fine interstitial pores; weakly cemented with silica; moderately alkaline (pH 8.0)"
   },
   "TYPE LOCATION": {
     "section": "TYPE LOCATION",
@@ -65,6 +65,94 @@
     ]
   ],
   "HORIZONS": [
-    {}
+    [
+      {
+        "name": "Ap",
+        "top": 0,
+        "bottom": 23,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 4,
+        "texture_class": "sandy loam",
+        "pH": 7.2,
+        "pH_class": "neutral",
+        "distinctness": "gradual",
+        "topography": "smooth",
+        "narrative": "Ap--0 to 9 inches; mixed pale brown and yellowish brown (10YR 6/3, 5/4) sandy loam, dark yellowish brown (10YR 4/4) moist; massive; hard, friable, slightly sticky and slightly plastic; common very fine, fine and medium roots; many very fine and fine interstitial pores; about 10 percent by volume 2 to 35 mm hardpan fragments which can be broken by hand; hardpan fragments have same color as soil matrix; neutral (pH 7.2); gradual smooth boundary. (4 to 12 inches thick)"
+      },
+      {
+        "name": "2C1",
+        "top": 23,
+        "bottom": 41,
+        "moist_hue": "7.5YR",
+        "moist_value": 4,
+        "moist_chroma": 4,
+        "texture_class": "sandy clay loam",
+        "pH": 8,
+        "pH_class": "moderately alkaline",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "2C1--9 to 16 inches; mixed light gray, white and brown (2.5Y 7/2, 8/2; 7.5Y 5/4) light sandy clay loam, grayish brown and brown (2.5Y 5/2; 7.5YR 4/4) moist; massive; hard, friable, sticky and slightly plastic; few very fine roots; common very fine and fine interstitial pores; common thin silica colloids bridging sand grains; about 10 percent by volume 2 to 35 mm hardpan fragments which can be broken by hand; hardpan fragments have same color as matrix; fragments of Bt (argillic) dark brown (7.5YR 4/4) moist clay and clay loam; about 5 percent by volume black (N 4/ ) Fe-Mn soft concretion ranging up to 5 mm in diameter; slightly calcareous with lime segregated in few fine filaments, moderately alkaline (pH 8.0); clear wavy boundary.  (0 to 20 inches thick)"
+      },
+      {
+        "name": "3C2",
+        "top": 41,
+        "bottom": 76,
+        "texture_class": "loamy sand",
+        "pH": 7.5,
+        "pH_class": "mildly alkaline",
+        "distinctness": "abrupt",
+        "topography": "smooth",
+        "narrative": "3C2--16 to 30 inches; mixed pale brown and brown (10YR 6/3, 7.5YR 5/4) loamy sand and sandy loam, dark brown (10YR 4/3, 7.5YR 4/4) moist; massive; hard, friable, nonsticky and slightly sticky and nonplastic and slightly plastic; few very fine roots; common very fine interstitial pores; about 3 percent by volume Bt (argillic) fragments having many very fine tubular pores and common thin clay films lining the tubular pores and common thin silica colloids bridging sand grains; in small pockets 20 percent by volume 2 to 5 mm gravels encased by loamy sand fill; about 25 percent by volume 5 to 35 mm hardpan fragments within small pockets in the lower 2/3 of the horizon having the same color as the horizon matrix; few black (N 2/) 2 to 5 mm Fe-Mn flakes; mildly alkaline (pH 7.5); abrupt smooth boundary.  (0 to 20 inches thick)"
+      },
+      {
+        "name": "4Ab",
+        "top": 76,
+        "bottom": 89,
+        "dry_hue": "10YR",
+        "dry_value": 5,
+        "dry_chroma": 2,
+        "moist_hue": "10YR",
+        "moist_value": 3,
+        "moist_chroma": 2,
+        "texture_class": "loam",
+        "pH": 6,
+        "distinctness": "gradual",
+        "topography": "wavy",
+        "narrative": "4Ab--30 to 35 inches; grayish brown (10YR 5/2) loam, very dark grayish brown (10YR 3/2) moist; common fine distinct yellowish red (5YR 5/6) mottles, dark reddish brown (5YR 3/4) moist; massive; hard, friable, slightly sticky and slightly plastic; common very fine roots; common very fine tubular and interstitial pores; 1/4 inch organic residue at top of horizon, few black (N 2/) 1 to 5 mm Fe-Mn concretions; medium acid (pH 6.0); gradual wavy boundary.  (0 to 10 inches thick)"
+      },
+      {
+        "name": "4C3",
+        "top": 89,
+        "bottom": 124,
+        "dry_hue": "10YR",
+        "dry_value": 5,
+        "dry_chroma": 3,
+        "moist_hue": "10YR",
+        "moist_value": 3,
+        "moist_chroma": 3,
+        "texture_class": "loam",
+        "pH": 7.5,
+        "pH_class": "mildly alkaline",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "4C3--35 to 49 inches; brown (10YR 5/3) loam, dark brown (10YR 3/3) moist; massive; hard, friable, slightly sticky and slightly plastic; few very fine roots; common very fine, fine and medium tubular and common very fine and fine interstitial pores; few black (N 2/) 1 to 5 mm Fe-Mn concretions; mildly alkaline (pH 7.5); clear wavy boundary. (0 to 20 inches thick)"
+      },
+      {
+        "name": "4Cq",
+        "top": 124,
+        "bottom": 152,
+        "dry_hue": "10YR",
+        "dry_value": 6,
+        "dry_chroma": 4,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 4,
+        "texture_class": "fine sandy loam",
+        "pH": 8,
+        "pH_class": "moderately alkaline",
+        "narrative": "4Cq--49 to 60 inches; light yellowish brown (10YR 6/4) fine sandy loam, dark yellowish brown (10YR 4/4) moist; massive; very hard, firm, slightly sticky and slightly plastic; no roots; few very fine interstitial pores; weakly cemented with silica; moderately alkaline (pH 8.0)"
+      }
+    ]
   ]
 }

--- a/inst/extdata/OSD/B/BAUMGARD.json
+++ b/inst/extdata/OSD/B/BAUMGARD.json
@@ -159,7 +159,6 @@
       },
       {
         "name": "Oa",
-        "top": 1,
         "narrative": "Oa--0.5 inch to 0; decomposed needles, twigs, and bark. (0.25 to 1 inch thick)"
       },
       {

--- a/inst/extdata/OSD/B/BAYUCOS.json
+++ b/inst/extdata/OSD/B/BAYUCOS.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 15,
+        "name": "C1g",
+        "top": 0,
+        "bottom": 15,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 1,
@@ -74,8 +75,9 @@
         "narrative": "C1g  --  0-6 inches, gray (10YR 6/1) fine sandy loam; common,"
       },
       {
-        "name": "6",
-        "top": 36,
+        "name": "C2g",
+        "top": 15,
+        "bottom": 36,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 1,
@@ -83,8 +85,9 @@
         "narrative": "C2g  --  6-14 inches, gray (10YR 5/1) loam; common, medium,"
       },
       {
-        "name": "14",
-        "top": 69,
+        "name": "C3g",
+        "top": 36,
+        "bottom": 69,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 2,
@@ -92,8 +95,9 @@
         "narrative": "C3g  --  14-27 inches, light brownish gray (10YR 6/2) loam;"
       },
       {
-        "name": "27",
-        "top": 114,
+        "name": "C4g",
+        "top": 69,
+        "bottom": 114,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 1,
@@ -101,8 +105,9 @@
         "narrative": "C4g  --  27-45 inches, gray (10YR 6/1) loam; few, fine faint,"
       },
       {
-        "name": "45",
-        "top": 152,
+        "name": "C5g",
+        "top": 114,
+        "bottom": 152,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 1,

--- a/inst/extdata/OSD/B/BEAL.json
+++ b/inst/extdata/OSD/B/BEAL.json
@@ -187,7 +187,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; slightly decomposed needles, leaves, and twigs."
       }
     ]

--- a/inst/extdata/OSD/B/BENHAM.json
+++ b/inst/extdata/OSD/B/BENHAM.json
@@ -203,7 +203,6 @@
       },
       {
         "name": "Oe",
-        "top": 11,
         "distinctness": "abrupt",
         "topography": "smooth",
         "narrative": "Oe--4.5 inches to 0; loose, partially decomposed organic litter, composed of needles, leaves, twigs, cones, bark chips, wood and roots; abrupt smooth boundary.  (1 to 6 inches thick)"

--- a/inst/extdata/OSD/B/BENKLIN.json
+++ b/inst/extdata/OSD/B/BENKLIN.json
@@ -67,8 +67,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 15,
+        "name": "Ap",
+        "top": 0,
+        "bottom": 15,
         "moist_hue": "10YR",
         "moist_value": 3,
         "moist_chroma": 2,
@@ -79,8 +80,9 @@
         "narrative": "Ap--0-6 inches, very dark grayish brown (10YR 3/2) silt loam, moderate medium granular structure; hard, friable; many fine roots; few worm channels; neutral; abrupt smooth boundary.  (5 to 18 inches thick)"
       },
       {
-        "name": "6",
-        "top": 46,
+        "name": "Bt1",
+        "top": 15,
+        "bottom": 46,
         "moist_hue": "10YR",
         "moist_value": 2,
         "moist_chroma": 2,
@@ -88,8 +90,9 @@
         "narrative": "Bt1--6-18 inches, very dark brown (10YR 2/2) loam; moderate very"
       },
       {
-        "name": "18",
-        "top": 84,
+        "name": "Bt2",
+        "top": 46,
+        "bottom": 84,
         "moist_hue": "10YR",
         "moist_value": 3,
         "moist_chroma": 2,
@@ -97,8 +100,9 @@
         "narrative": "Bt2--18-33 inches, very dark grayish brown (10YR 3/2) loam;"
       },
       {
-        "name": "33",
-        "top": 104,
+        "name": "Bt3",
+        "top": 84,
+        "bottom": 104,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 2,
@@ -106,8 +110,9 @@
         "narrative": "Bt3--33-41 inches, dark grayish brown (10YR 4/2) clay loam;"
       },
       {
-        "name": "41",
-        "top": 160,
+        "name": "Bt4",
+        "top": 104,
+        "bottom": 160,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 4,

--- a/inst/extdata/OSD/B/BEXAR.json
+++ b/inst/extdata/OSD/B/BEXAR.json
@@ -67,8 +67,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 20,
+        "name": "A1",
+        "top": 0,
+        "bottom": 20,
         "dry_hue": "5YR",
         "dry_value": 3,
         "dry_chroma": 2,
@@ -83,8 +84,9 @@
         "narrative": "A1--0-8 inches, dark reddish brown (5YR 3/2) cobbly clay loam, dark reddish brown (5YR 2/2) moist; moderate fine and very fine subangular blocky structure; hard, friable; common fine roots; few fine pores; about 15 percent by volume of pebble and cobble sized fragments of chert; slightly acid; clear wavy boundary.  (4 to 12 inches thick)"
       },
       {
-        "name": "8",
-        "top": 46,
+        "name": "A2",
+        "top": 20,
+        "bottom": 46,
         "dry_hue": "5YR",
         "dry_value": 3,
         "dry_chroma": 3,
@@ -99,8 +101,9 @@
         "narrative": "A2--8-18 inches, dark reddish brown (5YR 3/3) very cobbly clay loam, dark reddish brown (5YR 3/2) moist; moderate fine and very fine subangular blocky structure; hard, friable; common fine roots; few fine pores; about 40 percent by volume of cobble and pebble sized fragments of chert; slightly acid; abrupt wavy boundary.  (6 to 12 inches thick)"
       },
       {
-        "name": "18",
-        "top": 69,
+        "name": "Bt",
+        "top": 46,
+        "bottom": 69,
         "dry_hue": "2.5YR",
         "dry_value": 3,
         "dry_chroma": 4,
@@ -115,8 +118,9 @@
         "narrative": "Bt--18-27 inches, dark reddish brown (2.5YR 3/4) cobbly clay, dark reddish brown (2.5YR 2.5/4) moist; strong very fine blocky structure; very hard, firm; few fine roots; few fine pores; continuous thin clay films on surfaces of peds; about 20 percent by volume of pebble and cobble sized fragments of chert; slightly acid; abrupt wavy boundary.  (6 to 16 inches thick)"
       },
       {
-        "name": "27",
-        "top": 81,
+        "name": "R",
+        "top": 69,
+        "bottom": 81,
         "narrative": "R--27-32 inches, interbedded indurated and strongly cemented crystalline limestone, partially weathered in upper 2 inches."
       }
     ]

--- a/inst/extdata/OSD/B/BRIABBIT.json
+++ b/inst/extdata/OSD/B/BRIABBIT.json
@@ -10,8 +10,8 @@
     "content": "TAXONOMIC CLASS: Coarse-loamy, mixed, superactive, mesic Xeric Haplocalcids"
   },
   "TYPICAL PEDON": {
-    "section": "TYPICAL PEDON",
-    "content": null
+    "section": "TYPIC PEDON",
+    "content": "TYPIC PEDON:  Briabbit fine sandy loam -- on a east-facing slope of 8 percent, in native rangeland at 3,300 feet elevation.  (When described on June 18, 1984, the soil was dry throughout.  Colors are for air-dry soils unless otherwise stated.)\nA--0 to 3 inches; brown (10YR 4/3) fine sandy loam, very dark grayish brown (10YR 3/2) moist; weak coarse platy structure parting to weak fine subangular blocky; soft, very friable; common very fine, fine and medium, few coarse roots; common very fine and fine vesicular pores; 5 percent gravel; neutral (pH 7.3); clear smooth boundary.  (3 to 10 inches thick)\nBw--3 to 10 inches; brown (10YR 5/3) fine sandy loam, dark brown (10YR 3/3) moist; moderate coarse platy structure parting to moderate fine and medium subangular blocky; slightly hard, very friable; few very fine, medium and coarse roots; common fine tubular pores; 5 percent gravel; slightly alkaline (pH 7.6); clear wavy boundary.  (4 to 14 inches thick)\nBk--10 to 22 inches; pale brown (10YR 6/3) cobbly sandy loam, brown (10YR 4/3) moist; moderate fine and medium subangular blocky structure; slightly hard, friable; few very fine and fine roots; 10 percent gravel, 10 percent cobbles, lime coatings on rock fragments; strongly effervescent; strongly alkaline (pH 8.5); abrupt irregular boundary.  (10 to 24 inches thick)\nCr--22 inches; soft, highly fractured vitric tuff, lime partially fills fractures."
   },
   "TYPE LOCATION": {
     "section": "TYPE LOCATION",
@@ -65,6 +65,55 @@
     ]
   ],
   "HORIZONS": [
-    {}
+    [
+      {
+        "name": "A",
+        "top": 0,
+        "bottom": 8,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 3,
+        "texture_class": "fine sandy loam",
+        "pH": 7.3,
+        "pH_class": "neutral",
+        "distinctness": "clear",
+        "topography": "smooth",
+        "narrative": "A--0 to 3 inches; brown (10YR 4/3) fine sandy loam, very dark grayish brown (10YR 3/2) moist; weak coarse platy structure parting to weak fine subangular blocky; soft, very friable; common very fine, fine and medium, few coarse roots; common very fine and fine vesicular pores; 5 percent gravel; neutral (pH 7.3); clear smooth boundary.  (3 to 10 inches thick)"
+      },
+      {
+        "name": "Bw",
+        "top": 8,
+        "bottom": 25,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 3,
+        "texture_class": "fine sandy loam",
+        "pH": 7.6,
+        "pH_class": "slightly alkaline",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "Bw--3 to 10 inches; brown (10YR 5/3) fine sandy loam, dark brown (10YR 3/3) moist; moderate coarse platy structure parting to moderate fine and medium subangular blocky; slightly hard, very friable; few very fine, medium and coarse roots; common fine tubular pores; 5 percent gravel; slightly alkaline (pH 7.6); clear wavy boundary.  (4 to 14 inches thick)"
+      },
+      {
+        "name": "Bk",
+        "top": 25,
+        "bottom": 56,
+        "moist_hue": "10YR",
+        "moist_value": 6,
+        "moist_chroma": 3,
+        "texture_class": "sandy loam",
+        "cf_class": "cobbly",
+        "pH": 8.5,
+        "pH_class": "strongly alkaline",
+        "distinctness": "abrupt",
+        "topography": "irregular",
+        "narrative": "Bk--10 to 22 inches; pale brown (10YR 6/3) cobbly sandy loam, brown (10YR 4/3) moist; moderate fine and medium subangular blocky structure; slightly hard, friable; few very fine and fine roots; 10 percent gravel, 10 percent cobbles, lime coatings on rock fragments; strongly effervescent; strongly alkaline (pH 8.5); abrupt irregular boundary.  (10 to 24 inches thick)"
+      },
+      {
+        "name": "Cr",
+        "top": 56,
+        "narrative": "Cr--22 inches; soft, highly fractured vitric tuff, lime partially fills fractures."
+      }
+    ]
   ]
 }

--- a/inst/extdata/OSD/B/BRODY.json
+++ b/inst/extdata/OSD/B/BRODY.json
@@ -127,8 +127,7 @@
         "narrative": "Bs3--13 to 30 inches; brown (7.5YR 5/4) extremely gravelly silt loam, dark brown (7.5YR 3/4) moist; weak medium subangular blocky structure that parts to weak very fine and fine granular; slightly hard, very friable, slightly sticky and slightly plastic; common fine and medium roots; many very fine tubular pores; about 75 percent basalt fragments, mostly angular gravel and cobbles; slightly acid (pH 6 .1); gradual irregular boundary.  (5 to 20 inches thick)"
       },
       {
-        "name": "1/2",
-        "top": 1,
+        "name": "in",
         "dry_hue": "10YR",
         "dry_value": 2,
         "dry_chroma": 2,

--- a/inst/extdata/OSD/B/BROOKLYN.json
+++ b/inst/extdata/OSD/B/BROOKLYN.json
@@ -175,6 +175,19 @@
         "narrative": "2BCt--132 to 158 cm (52 to 62 inches); 50 percent yellowish brown (10YR 5/6), 30 percent light yellowish brown (2.5Y 6/3), and 20 percent gray (2.5Y 6/1) clay loam with thin strata of silt loam; massive; firm; very few distinct black (2.5Y 2.5/1) and very few distinct dark brown (7.5YR 3/2) organo-clay films lining pores and root channels; many medium spherical black (7.5YR 2.5/1) very weakly cemented iron-manganese nodules throughout; 5 percent gravel; neutral; gradual smooth boundary. [Combined thickness of the 2Btg, 2Bt, and 2BCt horizons is 10 to 61 cm (4 to 24 inches).]"
       },
       {
+        "name": "2C",
+        "top": 158,
+        "bottom": 185,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 6,
+        "texture_class": "sandy loam",
+        "pH_class": "slightly alkaline",
+        "distinctness": "clear",
+        "topography": "smooth",
+        "narrative": "2C--158 185 cm (62 to 73 inches); 60 percent yellowish brown (10YR 5/6) and 40 percent gray (2.5Y 5/1) loam with thin strata of sandy loam; massive; firm; many medium irregular black (7.5YR 2.5/1) masses of iron-manganese throughout; 7 percent gravel; slightly effervescent; slightly alkaline; clear smooth boundary. [ 0 to 51 cm (0 to 20 inches) thick.]"
+      },
+      {
         "name": "3Cd",
         "top": 185,
         "bottom": 203,

--- a/inst/extdata/OSD/B/BRYCE.json
+++ b/inst/extdata/OSD/B/BRYCE.json
@@ -163,6 +163,18 @@
         "texture_class": "silty clay",
         "pH_class": "slightly alkaline",
         "narrative": "2Cg--147 to 168 cm  (58 to 66 inches); gray (5Y 5/1) silty clay; massive; very firm; many medium prominent olive brown (2.5Y 4/4) iron-manganese accumulations in the matrix; 3 percent gravel; slightly effervescent; slightly alkaline."
+      },
+      {
+        "name": "2BCg",
+        "top": 114,
+        "moist_hue": "5Y",
+        "moist_value": 5,
+        "moist_chroma": 1,
+        "texture_class": "silty clay",
+        "pH_class": "moderately alkaline",
+        "distinctness": "clear",
+        "topography": "smooth",
+        "narrative": "2BCg--114 to147 cm (45 to 58 inches); gray (5Y 5/1) silty clay; weak very coarse prismatic structure; very firm; few fine white (10YR 8/1) very weakly cemented nodules and concretions of calcium carbonate throughout; common coarse prominent brown (10YR 4/3) iron-manganese accumulations and common medium prominent yellowish brown (10YR 5/6) masses of oxidized iron in the matrix; 1 percent gravel; slightly effervescent; moderately alkaline; clear smooth boundary. [13 to 38 cm (5 to 15 inches) thick]"
       }
     ]
   ]

--- a/inst/extdata/OSD/B/BUCKSHOT.json
+++ b/inst/extdata/OSD/B/BUCKSHOT.json
@@ -134,7 +134,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; partially decomposed needles and twigs."
       }
     ]

--- a/inst/extdata/OSD/C/CARIBEL.json
+++ b/inst/extdata/OSD/C/CARIBEL.json
@@ -180,7 +180,6 @@
       },
       {
         "name": "Oa",
-        "top": 1,
         "dry_hue": "10YR",
         "dry_value": 3,
         "dry_chroma": 2,

--- a/inst/extdata/OSD/C/CERPONE.json
+++ b/inst/extdata/OSD/C/CERPONE.json
@@ -182,7 +182,6 @@
       },
       {
         "name": "R",
-        "top": 144,
         "narrative": "R--56.5 inches (144 cm); very strongly cemented ultramafic bedrock."
       }
     ]

--- a/inst/extdata/OSD/C/CHAPOT.json
+++ b/inst/extdata/OSD/C/CHAPOT.json
@@ -156,7 +156,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; decomposing forest litter."
       }
     ]

--- a/inst/extdata/OSD/C/CHAPPELL.json
+++ b/inst/extdata/OSD/C/CHAPPELL.json
@@ -83,6 +83,22 @@
         "narrative": "A1--0 to 18 centimeters 0 to 7 inches; dark grayish brown (10YR 4/2) fine sandy loam, very dark grayish brown (10YR 3/2) moist; weak fine granular structure; slightly hard, friable; neutral; abrupt smooth boundary."
       },
       {
+        "name": "A2",
+        "top": 18,
+        "bottom": 43,
+        "dry_hue": "10YR",
+        "dry_value": 4,
+        "dry_chroma": 2,
+        "moist_hue": "10YR",
+        "moist_value": 3,
+        "moist_chroma": 3,
+        "texture_class": "fine sandy loam",
+        "pH_class": "neutral",
+        "distinctness": "clear",
+        "topography": "smooth",
+        "narrative": "A2--18 43 centimeters (7 to 17 inches); dark grayish brown (10YR 4/2) fine sandy loam, dark brown (10YR 3/3) moist; weak medium subangular blocky structure; slightly hard, friable; neutral; clear smooth boundary.  (7 to 20 inches thick)"
+      },
+      {
         "name": "Bw",
         "top": 43,
         "bottom": 64,

--- a/inst/extdata/OSD/C/COLIBRO.json
+++ b/inst/extdata/OSD/C/COLIBRO.json
@@ -99,6 +99,22 @@
         "narrative": "Bk1--15 to 41 cm (6 to 16 in); grayish brown (10YR 5/2) sandy clay loam, dark grayish brown (10YR 4/2) moist; moderate medium subangular blocky structure; hard, friable; many fine roots; few fragments of snail shells; few films, threads and concretions of calcium carbonate; violently effervescent; moderately alkaline; gradual smooth boundary. (10 to 30 cm [4 to 12 in] thick)"
       },
       {
+        "name": "Bk2",
+        "top": 41,
+        "bottom": 81,
+        "dry_hue": "10YR",
+        "dry_value": 6,
+        "dry_chroma": 3,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 3,
+        "texture_class": "loam",
+        "pH_class": "moderately alkaline",
+        "distinctness": "gradual",
+        "topography": "smooth",
+        "narrative": "Bk2--41 81 cm (16 to 32 in); pale brown (10YR 6/3) loam, brown (10YR 5/3) moist; moderate fine subangular blocky structure; hard, friable; few fragments of snail shells; 5 percent films, threads, and concretions of calcium carbonate; violently effervescent; moderately alkaline; gradual smooth boundary. (20 to 51 cm [8 to 20 in] thick)"
+      },
+      {
         "name": "Bk3",
         "top": 81,
         "bottom": 122,

--- a/inst/extdata/OSD/C/CORA.json
+++ b/inst/extdata/OSD/C/CORA.json
@@ -81,8 +81,9 @@
         "narrative": "Alg--0 to 12 inches; Gray (2.5Y 6/1 dry) to dark gray (2.5Y 4/1 moist) clay loam; very hard when dry, friable when moist; massive to very weak very coarse granular structure; noncalcareous, slightly acid to neutral reaction; there are common numbers of large distinct 10YR 3/4 mottles; lower boundary gradual and smooth. 6-15n thick"
       },
       {
-        "name": "12",
-        "top": 71,
+        "name": "B2g",
+        "top": 30,
+        "bottom": 71,
         "moist_hue": "5Y",
         "moist_value": 6,
         "moist_chroma": 4,
@@ -91,8 +92,9 @@
         "narrative": "B2g--12-28 inches; Pale olive (5Y 6/3 dry) to olive (5Y 5/3 moist) clay loam or heavy sandy clay loam; very hard when dry, friable when moist; massive; noncalcareous, slightly acid to neutral reaction; many large prominent (5Y 6/4) mottles making up 30 to 40 percent of the soil mass; lower boundary gradual and smooth. 12-20 inches thick"
       },
       {
-        "name": "28",
-        "top": 152,
+        "name": "IICg",
+        "top": 71,
+        "bottom": 152,
         "texture_class": "sand",
         "narrative": "IICg--28-60 inches; Light gray (5Y 7/2 dry) to olive gray (5Y 5/2 moist) coarse  sand and cobble."
       }

--- a/inst/extdata/OSD/C/CORBIERE.json
+++ b/inst/extdata/OSD/C/CORBIERE.json
@@ -196,8 +196,9 @@
         "narrative": "3C2--96 to 114 inches; light olive brown (2.5Y 5/4) clay; gray (10YR 5/1) redoximorphic depletions; moderately alkaline (pH 8.0)."
       },
       {
-        "name": "74",
-        "top": 244,
+        "name": "3C1",
+        "top": 188,
+        "bottom": 244,
         "dry_hue": "2.5Y",
         "dry_value": 5,
         "dry_chroma": 2,

--- a/inst/extdata/OSD/C/CRAFTON.json
+++ b/inst/extdata/OSD/C/CRAFTON.json
@@ -132,7 +132,7 @@
       },
       {
         "name": "02",
-        "top": 1,
+        "bottom": 5,
         "narrative": "01 and 02--0.5 inch to 0; partly decomposed brush litter (1/2 to 1 1/2 inches thick)"
       }
     ]

--- a/inst/extdata/OSD/C/CUMBERLAND.json
+++ b/inst/extdata/OSD/C/CUMBERLAND.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 20,
+        "name": "Ap",
+        "top": 0,
+        "bottom": 20,
         "moist_hue": "5YR",
         "moist_value": 3,
         "moist_chroma": 4,
@@ -76,8 +77,9 @@
         "narrative": "Ap--  0-8 inches, dark reddish brown (5YR 3/4) silt loam; moderate medium granular structure; friable; many fine roots and pores; few fine black and dark brown concretions; medium acid; abrupt smooth boundary.  (5 to 10 inches thick)"
       },
       {
-        "name": "8",
-        "top": 36,
+        "name": "B1",
+        "top": 20,
+        "bottom": 36,
         "moist_hue": "2.5YR",
         "moist_value": 3,
         "moist_chroma": 4,
@@ -87,8 +89,9 @@
         "narrative": "B1--  8-14 inches, dark reddish brown (2.5YR 3/4) silty clay loam; moderate medium subangular blocky structure; friable; common fine roots and pores; thin patchy clay films; common fine dark concretions; medium acid; clear smooth boundary.  (4 to 9 inches thick)"
       },
       {
-        "name": "14",
-        "top": 69,
+        "name": "B21t",
+        "top": 36,
+        "bottom": 69,
         "moist_hue": "2.5YR",
         "moist_value": 3,
         "moist_chroma": 6,
@@ -97,8 +100,9 @@
         "narrative": "B21t  --  14-27 inches, dark red (2.5YR 3/6) clay; moderate medium subangular blocky structure; firm; common  fine roots; thick patchy clay films; common fine dark concretions; strongly acid; diffuse smoothboundary.  (12 to 20 inches thick)"
       },
       {
-        "name": "27",
-        "top": 102,
+        "name": "B22t",
+        "top": 69,
+        "bottom": 102,
         "moist_hue": "2.5YR",
         "moist_value": 3,
         "moist_chroma": 6,
@@ -109,8 +113,9 @@
         "narrative": "B22t  --  27-40 inches, dark red (2.5YR 3/6) clay; moderate medium and fine subangular blocky structure; firm; few fine roots and pores; thin continuous clay films; many fine dark concretions; strongly acid; gradual smooth boundary.  (12 to 20 inches thick)"
       },
       {
-        "name": "40",
-        "top": 122,
+        "name": "B23t",
+        "top": 102,
+        "bottom": 122,
         "moist_hue": "2.5YR",
         "moist_value": 3,
         "moist_chroma": 6,
@@ -121,8 +126,9 @@
         "narrative": "B23t  --  40-48 inches, dark red (2.5YR 3/6) clay; moderate medium angular and subangular blocky structure; firm; few fine roots and pores; thin continuous clay films; many fine dark concretions; strongly acid; gradual smooth boundary.  (6 to 12 inches thick)"
       },
       {
-        "name": "48",
-        "top": 163,
+        "name": "B24t",
+        "top": 122,
+        "bottom": 163,
         "moist_hue": "2.5YR",
         "moist_value": 4,
         "moist_chroma": 6,

--- a/inst/extdata/OSD/C/CUTCOMB.json
+++ b/inst/extdata/OSD/C/CUTCOMB.json
@@ -79,6 +79,18 @@
         "narrative": "Oe1--0 to 36 centimeters (0 to 14 inches); dark brown (7.5YR 3/2) unrubbed mucky peat, very dark brown (10YR 2/2) rubbed; about 50 percent fiber, 20 percent rubbed; weak medium granular structure; very friable; many very fine and fine roots; herbaceous fibers; moderately acid; gradual wavy boundary. (18 to 53 centimeters (7 to 21 inches) thick)"
       },
       {
+        "name": "Oe2",
+        "top": 36,
+        "bottom": 58,
+        "moist_hue": "10YR",
+        "moist_value": 2,
+        "moist_chroma": 2,
+        "pH_class": "moderately acid",
+        "distinctness": "clear",
+        "topography": "smooth",
+        "narrative": "Oe2--36 58 centimeters (14 to 23 inches); very dark brown (10YR 2/2) mucky peat; about 65 percent fiber, 10 percent rubbed; weak thick platy structure; very friable; few very fine and fine roots; herbaceous fibers; moderately acid; clear smooth boundary."
+      },
+      {
         "name": "Oe3",
         "top": 58,
         "bottom": 74,

--- a/inst/extdata/OSD/D/DANDRIDGE.json
+++ b/inst/extdata/OSD/D/DANDRIDGE.json
@@ -129,8 +129,9 @@
         "narrative": "BC--12 to 17 inches; light yellowish brown (10YR 6/4) very channery silty clay loam; weak fine subangular blocky structure; friable; common fine and medium and few coarse roots; common fine tubular pores; 60 percent fragments of shale and limestone up to 5 inches in diameter; moderately alkaline; clear wavy boundary."
       },
       {
-        "name": "17",
-        "top": 89,
+        "name": "Cr",
+        "top": 43,
+        "bottom": 89,
         "narrative": "Cr--17-35 inches; weathered calcaraeous shale bedrock with a few thin strata of limestone."
       },
       {

--- a/inst/extdata/OSD/D/DIXMINE.json
+++ b/inst/extdata/OSD/D/DIXMINE.json
@@ -182,7 +182,6 @@
       },
       {
         "name": "Cr",
-        "top": 136,
         "narrative": "Cr--53.5 inches (136 cm); very weathered moderately cemented metatuff; beds are less than 4 inches (10 cm) apart; roots are greater than 4 inches (10 cm) apart."
       }
     ]

--- a/inst/extdata/OSD/D/DUNSMUIR.json
+++ b/inst/extdata/OSD/D/DUNSMUIR.json
@@ -123,7 +123,7 @@
       },
       {
         "name": "0",
-        "top": 1,
+        "bottom": 0,
         "narrative": "0--0.25 inch to 0; duff of partially decomposed and undecomposed leaves and twigs."
       },
       {

--- a/inst/extdata/OSD/F/FEAGINRANCH.json
+++ b/inst/extdata/OSD/F/FEAGINRANCH.json
@@ -183,7 +183,6 @@
       },
       {
         "name": "Oi",
-        "top": 14,
         "narrative": "Oi--5.5 inches to 0; dense root mat of mostly live roots and some slightly decomposed roots. (3 to 7 inches thick)"
       }
     ]

--- a/inst/extdata/OSD/F/FEDSCREEK.json
+++ b/inst/extdata/OSD/F/FEDSCREEK.json
@@ -172,6 +172,19 @@
         "narrative": "C2--155 to 168 cm (61to 66 inches); dark yellowish brown (10YR 4/6) channery silt loam with few medium distinct light yellowish brown (2.5Y 6/4) lithochromic mottles; massive; firm; 30 percent sandstone fragments; very strongly acid; abrupt smooth boundary. (0 to 51cm, 0 to 20 inches thick or more)"
       },
       {
+        "name": "Bw2",
+        "top": 43,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 6,
+        "texture_class": "sand",
+        "cf_class": "channery",
+        "pH_class": "very strongly acid",
+        "distinctness": "clear",
+        "topography": "smooth",
+        "narrative": "Bw2-- 43 to79 cm (17 to 31 inches); yellowish brown (10YR 5/6) channery loam; moderate medium angular blocky structure; friable; few fine to coarse roots; 20 percent sandstone fragments; very strongly acid; clear smooth boundary."
+      },
+      {
         "name": "R",
         "top": 168,
         "texture_class": "sand",

--- a/inst/extdata/OSD/G/GALILEE.json
+++ b/inst/extdata/OSD/G/GALILEE.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 20,
+        "name": "A1",
+        "top": 0,
+        "bottom": 20,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 2,
@@ -77,8 +78,9 @@
         "narrative": "A1   --  0-8 inches, grayish brown (10YR 5/2) fine sandy loam; massive and weak subangular blocky structure; hard, friable; many fine, medium, and coarse roots; common fine pores; slightly acid; clear smooth boundary.  (4 to 8 inches thick)"
       },
       {
-        "name": "8",
-        "top": 48,
+        "name": "B21t",
+        "top": 20,
+        "bottom": 48,
         "moist_hue": "5YR",
         "moist_value": 4,
         "moist_chroma": 6,
@@ -86,8 +88,9 @@
         "narrative": "B21t --  8-19 inches, yellowish red (5YR 4/6) clay; moderate medium subangular blocky structure; very hard, firm, sticky and plastic; common fine, medium, and coarse roots; few fine pores;"
       },
       {
-        "name": "19",
-        "top": 66,
+        "name": "B22t",
+        "top": 48,
+        "bottom": 66,
         "moist_hue": "5YR",
         "moist_value": 4,
         "moist_chroma": 4,
@@ -96,8 +99,9 @@
         "narrative": "B22t --  19-26 inches, reddish brown (5YR 4/4) clay; moderate medium and coarse blocky  structure; very hard, firm, sticky and plastic; few fine, medium, and coarse roots;  few fine pores; thin continuous clay films on faces of peds; very strongly acid;"
       },
       {
-        "name": "26",
-        "top": 81,
+        "name": "B23t",
+        "top": 66,
+        "bottom": 81,
         "moist_hue": "5YR",
         "moist_value": 5,
         "moist_chroma": 4,
@@ -105,16 +109,18 @@
         "narrative": "B23t --  26-32 inches, reddish brown (5YR 5/4) sandy clay"
       },
       {
-        "name": "32",
-        "top": 97,
+        "name": "B3",
+        "top": 81,
+        "bottom": 97,
         "moist_hue": "5YR",
         "moist_value": 4,
         "moist_chroma": 6,
         "narrative": "B3   --  32-38 inches, mottled yellowish red (5YR 4/6) and"
       },
       {
-        "name": "38",
-        "top": 127,
+        "name": "Cr",
+        "top": 97,
+        "bottom": 127,
         "moist_hue": "5YR",
         "moist_value": 5,
         "moist_chroma": 4,

--- a/inst/extdata/OSD/G/GALTSMILL.json
+++ b/inst/extdata/OSD/G/GALTSMILL.json
@@ -65,6 +65,60 @@
     ]
   ],
   "HORIZONS": [
-    {}
+    [
+      {
+        "name": "Ap",
+        "top": 0,
+        "bottom": 38,
+        "dry_hue": "10YR",
+        "dry_value": 5,
+        "dry_chroma": 3,
+        "moist_hue": "10YR",
+        "moist_value": 3,
+        "moist_chroma": 2,
+        "texture_class": "fine sandy loam",
+        "pH_class": "slightly acid",
+        "distinctness": "abrupt",
+        "topography": "smooth",
+        "narrative": "Ap=0 to 15 inches; very dark grayish brown (10YR 3/2) broken, dark brown (10YR 3/3) crushed, fine sandy loam; brown (10YR 5/3) dry; moderate medium granular structure; friable; common fine and medium roots; common fine flakes of mica; slightly acid; abrupt smooth boundary. (Ap and A horizons are 10 to 24 inches thick)"
+      },
+      {
+        "name": "Bw1",
+        "top": 38,
+        "bottom": 89,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 3,
+        "texture_class": "fine sandy loam",
+        "pH_class": "slightly acid",
+        "distinctness": "clear",
+        "topography": "smooth",
+        "narrative": "Bw1=15 to 35 inches; brown (10YR 4/3) fine sandy loam; weak coarse subangular blocky structure; friable; few fine roots; common fine flakes of mica; slightly acid; clear smooth boundary."
+      },
+      {
+        "name": "Bw2",
+        "top": 89,
+        "bottom": 122,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 3,
+        "texture_class": "loam",
+        "pH_class": "slightly acid",
+        "distinctness": "clear",
+        "topography": "smooth",
+        "narrative": "Bw2=35 to 48 inches; brown (10YR 4/3) loam; weak coarse subangular blocky structure; friable; few fine roots; common fine flakes of mica; slightly acid; clear smooth boundary."
+      },
+      {
+        "name": "Bw3",
+        "top": 122,
+        "bottom": 183,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 3,
+        "texture_class": "fine sandy loam",
+        "pH_class": "slightly acid",
+        "narrative": "Bw3=48 to 72 inches; brown (10YR 4/3) fine sandy loam; weak coarse subangular blocky structure; friable; few fine roots; common fine flakes of mica; slightly acid. (Combined thickness of the Bw horizon is 20 to 60 inches or more)"
+      }
+    ]
   ]
 }

--- a/inst/extdata/OSD/G/GAVEL.json
+++ b/inst/extdata/OSD/G/GAVEL.json
@@ -147,7 +147,7 @@
       },
       {
         "name": "0",
-        "top": 4,
+        "bottom": 0,
         "distinctness": "abrupt",
         "topography": "smooth",
         "narrative": "0--1.5 inch to 0; loose, fresh and partially decomposed mat of needles, twigs, and pine cones; abrupt smooth boundary."

--- a/inst/extdata/OSD/G/GOREEN.json
+++ b/inst/extdata/OSD/G/GOREEN.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 33,
+        "name": "A",
+        "top": 0,
+        "bottom": 33,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 2,
@@ -74,8 +75,9 @@
         "narrative": "A     --  0-13 inches, grayish brown (10YR 5/2) fine sandy"
       },
       {
-        "name": "13",
-        "top": 66,
+        "name": "B21tg",
+        "top": 33,
+        "bottom": 66,
         "moist_hue": "7.5YR",
         "moist_value": 4,
         "moist_chroma": 2,
@@ -83,8 +85,9 @@
         "narrative": "B21tg --  13-26 inches, dark brown (7.5YR 4/2) clay; many"
       },
       {
-        "name": "26",
-        "top": 79,
+        "name": "B22tg",
+        "top": 66,
+        "bottom": 79,
         "moist_hue": "7.5YR",
         "moist_value": 4,
         "moist_chroma": 2,
@@ -92,8 +95,9 @@
         "narrative": "B22tg --  26-31 inches, dark brown (7.5YR 4/2) clay; common medium distinct yellowish red (5YR 4/6) mottles; moderate fine"
       },
       {
-        "name": "31",
-        "top": 102,
+        "name": "Cr",
+        "top": 79,
+        "bottom": 102,
         "texture_class": "sand",
         "narrative": "Cr     --  31-40 inches, weakly cemented sandstone interbedded"
       }

--- a/inst/extdata/OSD/G/GREENDALE.json
+++ b/inst/extdata/OSD/G/GREENDALE.json
@@ -116,6 +116,17 @@
         "distinctness": "clear",
         "topography": "smooth",
         "narrative": "Ab--71 to 86 cm (28 to 34 inches); dark brown (10YR 3/3) silt loam; moderate medium granular structure; friable; few fine roots; about 10 percent by volume fragments of chert up to 51 mm (2 inches) in size; strongly acid; clear smooth boundary. (0 to 30 cm thick)"
+      },
+      {
+        "name": "Bwb",
+        "top": 86,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 4,
+        "texture_class": "silt loam",
+        "cf_class": "gravelly",
+        "pH_class": "strongly acid",
+        "narrative": "Bwb--86 to152 cm (34 to 60 inches); yellowish brown (10YR 5/4) gravelly silt loam; few medium distinct pale brown (10YR 6/3), light brownish gray (10YR 6/2), and dark brown (10YR 3/3) mottles; weak medium subangular blocky structure; friable; 15 percent by volume fragments of chert up to 75 mm (3 inches) in size; strongly acid."
       }
     ]
   ]

--- a/inst/extdata/OSD/G/GUDGREY.json
+++ b/inst/extdata/OSD/G/GUDGREY.json
@@ -153,7 +153,7 @@
       },
       {
         "name": "0",
-        "top": 4,
+        "bottom": 0,
         "narrative": "0--1.5 inches to 0; undecomposed and partially decomposed conifer needles, bark and twigs."
       }
     ]

--- a/inst/extdata/OSD/G/GUNTER.json
+++ b/inst/extdata/OSD/G/GUNTER.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 13,
+        "name": "A1",
+        "top": 0,
+        "bottom": 13,
         "moist_hue": "10YR",
         "moist_value": 3,
         "moist_chroma": 2,
@@ -76,8 +77,9 @@
         "narrative": "A1   --  0-5 inches, very dark grayish brown (10YR 3/2) fine sand; single grained; loose, very friable; many fine and medium roots; medium acid; clear wavy boundary.  (3 to 6 inches thick)"
       },
       {
-        "name": "5",
-        "top": 79,
+        "name": "A21",
+        "top": 13,
+        "bottom": 79,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 4,
@@ -85,8 +87,9 @@
         "narrative": "A21  --  5-31 inches, light yellowish brown (10YR 6/4) fine sand; few medium distinct brown (7.5YR 5/6) mottles; single"
       },
       {
-        "name": "31",
-        "top": 117,
+        "name": "A22",
+        "top": 79,
+        "bottom": 117,
         "moist_hue": "10YR",
         "moist_value": 7,
         "moist_chroma": 4,
@@ -97,8 +100,9 @@
         "narrative": "A22  --  31-46 inches, very pale brown (10YR 7/4) fine sand; common coarse distinct brown (7.5YR 5/4) mottles that are slightly harder than the surrounding material; single grained; slightly brittle, loose; common fine and medium roots; few nodules of ironstone and pebbles of chert up to 1/2 inch in diameter; very strongly acid; clear wavy boundary.  (10 to 20 inches thick)"
       },
       {
-        "name": "46",
-        "top": 145,
+        "name": "B1",
+        "top": 117,
+        "bottom": 145,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 6,
@@ -106,8 +110,9 @@
         "narrative": "B1   --  46-57 inches, yellowish brown (10YR 5/6) sandy loam; common medium distinct yellowish red (5YR 5/6) mottles of loam material that are slightly brittle; massive; friable; common fine"
       },
       {
-        "name": "57",
-        "top": 190,
+        "name": "B2t",
+        "top": 145,
+        "bottom": 190,
         "moist_hue": "10R",
         "moist_value": 4,
         "moist_chroma": 6,

--- a/inst/extdata/OSD/G/GUYANDOTTE.json
+++ b/inst/extdata/OSD/G/GUYANDOTTE.json
@@ -160,6 +160,11 @@
         "cf_class": "extremely channery",
         "pH_class": "moderately acid",
         "narrative": "Bw2--104 to 170 centimeters (41 to 67 inches); yellowish brown (10YR 5/4) extremely channery sandy loam; weak medium subangular blocky structure; friable; few fine, medium and coarse roots; 65 percent channers and stones; moderately acid. Combined thickness of the Bw horizon is 76 to 142 centimeters (30 to 56 inches)"
+      },
+      {
+        "name": "Oi",
+        "top": 0,
+        "narrative": "Oi--0 to5 centimeters (0 to 2 inches); slightly decomposed  hardwood leaves."
       }
     ]
   ]

--- a/inst/extdata/OSD/H/HESSEL.json
+++ b/inst/extdata/OSD/H/HESSEL.json
@@ -97,6 +97,22 @@
         "cf_class": "cobbly",
         "pH_class": "slightly alkaline",
         "narrative": "Cg--33 to 127 cm (13 to 50 inches); light brownish gray (2.5Y 6/2) cobbly loam; weak medium subangular blocky structure; firm; many medium distinct dark yellowish brown (10YR 4/4) masses of oxidized iron; about 30 percent rock fragments; slightly effervescent; slightly alkaline."
+      },
+      {
+        "name": "A",
+        "top": 0,
+        "dry_hue": "10YR",
+        "dry_value": 5,
+        "dry_chroma": 2,
+        "moist_hue": "10YR",
+        "moist_value": 2,
+        "moist_chroma": 2,
+        "texture_class": "loam",
+        "cf_class": "cobbly",
+        "pH_class": "slightly alkaline",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "A--0 to20 cm (8 inches); very dark brown (10YR 2/2) cobbly loam, grayish brown (10YR 5/2) dry; moderate medium granular structure; friable; about 25 percent rock fragments; slightly alkaline; clear wavy boundary. [13 to 25 cm (5 to 10 inches) thick]"
       }
     ]
   ]

--- a/inst/extdata/OSD/H/HEWENT.json
+++ b/inst/extdata/OSD/H/HEWENT.json
@@ -141,7 +141,6 @@
       },
       {
         "name": "R",
-        "top": 67,
         "narrative": "R--67.0 centimeters (26 inches); metavolcanic bedrock, fractured at intervals of 10 to 45 centimeters."
       }
     ]

--- a/inst/extdata/OSD/H/HIBERNIA.json
+++ b/inst/extdata/OSD/H/HIBERNIA.json
@@ -149,6 +149,17 @@
         "distinctness": "clear",
         "topography": "smooth",
         "narrative": "C1--36 to 62 inches; light olive brown (2.5Y 5/4) gravelly sandy loam; massive; firm; few very fine continuous pores; 25 percent gravel, cobbles, and stones; common coarse distinct light brownish gray (2.5Y 6/2) iron depletions and common coarse prominent yellowish brown (10YR 5/8) and brown (7.5YR 4/4) iron accumulations; strongly acid; clear smooth boundary."
+      },
+      {
+        "name": "C2",
+        "top": 157,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 3,
+        "texture_class": "loamy sand",
+        "cf_class": "very gravelly",
+        "pH_class": "strongly acid",
+        "narrative": "C2--62 to72 inches; brown (10YR 5/3) and light olive brown (2.5Y 5/4) very gravelly loamy sand; single grain; loose; 40 percent gravel, cobbles, and stones, strongly acid."
       }
     ]
   ]

--- a/inst/extdata/OSD/H/HICOTA.json
+++ b/inst/extdata/OSD/H/HICOTA.json
@@ -67,8 +67,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 10,
+        "name": "A",
+        "top": 0,
+        "bottom": 10,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 3,
@@ -76,8 +77,9 @@
         "narrative": "A--0-4 inches, brown (10YR 4/3) very fine sandy loam; very pale"
       },
       {
-        "name": "4",
-        "top": 36,
+        "name": "E",
+        "top": 10,
+        "bottom": 36,
         "dry_hue": "10YR",
         "dry_value": 7,
         "dry_chroma": 3,
@@ -90,16 +92,18 @@
         "narrative": "E--4-14 inches, light yellowish brown (10YR 6/4) very fine sandy loam; very pale brown (10YR 7/3) dry; weak fine granular structure; slightly hard, very friable; common fine grass roots; medium acid; gradual wavy boundary.  (4 to 17 inches thick)"
       },
       {
-        "name": "14",
-        "top": 81,
+        "name": "E/Bt",
+        "top": 36,
+        "bottom": 81,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 4,
         "narrative": "E/Bt--14-32 inches, light yellowish brown (10YR 6/4) very fine"
       },
       {
-        "name": "32",
-        "top": 112,
+        "name": "Bt/E1",
+        "top": 81,
+        "bottom": 112,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 6,
@@ -107,8 +111,9 @@
         "narrative": "Bt/E1--32-44  inches, yellowish brown (10YR 5/6) loam; common"
       },
       {
-        "name": "44",
-        "top": 137,
+        "name": "Bt/E2",
+        "top": 112,
+        "bottom": 137,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 6,
@@ -119,8 +124,9 @@
         "narrative": "Bt/E2--44-54 inches, yellowish brown (10YR 5/6) clay loam; common medium distinct light brownish gray (10YR 6/2) and prominent red (2.5YR 4/6) mottles; moderate coarse prismatic structure parting to weak medium subangular blocky structure; very hard, firm; few roots, mostly between peds; common fine and medium pores; about 5 percent white (10YR 8/1) sand and silt on prism faces (E); thick clay films; very strongly acid; gradual smooth boundary.  (7 to 23 inches thick)"
       },
       {
-        "name": "54",
-        "top": 170,
+        "name": "Bt1",
+        "top": 137,
+        "bottom": 170,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 1,
@@ -128,8 +134,9 @@
         "narrative": "Bt1--54-67 inches, gray (10YR 6/1) clay loam; common medium"
       },
       {
-        "name": "67",
-        "top": 203,
+        "name": "Bt2",
+        "top": 170,
+        "bottom": 203,
         "moist_hue": "2.5Y",
         "moist_value": 6,
         "moist_chroma": 2,

--- a/inst/extdata/OSD/H/HORNSBY.json
+++ b/inst/extdata/OSD/H/HORNSBY.json
@@ -122,8 +122,9 @@
         "narrative": "2C--70 to 82 inches, light gray (2.5Y 7/2) gravelly clay, light brownish gray (2.5Y 6/2) moist, few fine distinct olive yellow mottles; massive; very hard, very firm; few fine pores; 15 percent very coarse pebbles of quartz and feldspar; few medium black-brown concretions; slightly acid."
       },
       {
-        "name": "37",
-        "top": 178,
+        "name": "Bt2",
+        "top": 94,
+        "bottom": 178,
         "dry_hue": "5YR",
         "dry_value": 6,
         "dry_chroma": 6,

--- a/inst/extdata/OSD/H/HUFMAN.json
+++ b/inst/extdata/OSD/H/HUFMAN.json
@@ -99,6 +99,18 @@
         "distinctness": "gradual",
         "topography": "wavy",
         "narrative": "Cg1--26 to 34 inches; dark greenish gray (5GY 4/1); silt loam; massive; very friable, nonsticky and nonplastic; reduced matrix; slightly acid (pH 6.4); gradual wavy boundary. (6 to 20 inches thick)"
+      },
+      {
+        "name": "Cg2",
+        "top": 86,
+        "bottom": 152,
+        "moist_hue": "5GY",
+        "moist_value": 4,
+        "moist_chroma": 1,
+        "texture_class": "fine sand",
+        "pH": 6.4,
+        "pH_class": "slightly acid",
+        "narrative": "Cg2=34 to 60 inches; dark greenish gray (5GY 4/1); stratified fine sand through silt with composite texture of loam; massive; very friable, nonsticky and nonplastic; reduced matrix; slightly acid (pH 6.4)."
       }
     ]
   ]

--- a/inst/extdata/OSD/H/HUNTSBURG.json
+++ b/inst/extdata/OSD/H/HUNTSBURG.json
@@ -67,8 +67,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 15,
+        "name": "A",
+        "top": 0,
+        "bottom": 15,
         "dry_hue": "10YR",
         "dry_value": 6,
         "dry_chroma": 3,
@@ -82,8 +83,9 @@
         "narrative": "A--0-6 inches, brown (10YR 5/3) loamy fine sand, pale brown (10YR 6/3) dry; weak fine granular structure; soft, very friable; many fine and medium roots, common coarse roots; common fine and medium pores; slightly acid; clear smooth boundary.  (4 to 8 inches thick)"
       },
       {
-        "name": "6",
-        "top": 36,
+        "name": "E",
+        "top": 15,
+        "bottom": 36,
         "dry_hue": "10YR",
         "dry_value": 7,
         "dry_chroma": 4,
@@ -96,8 +98,9 @@
         "narrative": "E--6-14 inches, light yellowish brown (10YR 6/4) loamy fine sand, very pale brown (10YR 7/4) dry; single grained; soft, very friable; many fine and medium roots, common coarse roots; common fine and medium pores; few nodules of ironstone 4 mm. to 10 mm. in diameter; medium acid; abrupt wavy boundary.  (7 to 12 inches thick)"
       },
       {
-        "name": "14",
-        "top": 56,
+        "name": "Bt1",
+        "top": 36,
+        "bottom": 56,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 8,
@@ -108,16 +111,18 @@
         "narrative": "Bt1--14-22 inches, yellowish brown (10YR 5/8) sandy clay; few fine prominent red mottles; moderate fine subangular blocky structure; very hard, firm; many medium and coarse roots; common fine pores; thin patchy clay films on faces of peds; few nodules of ironstone 4 mm. to 10 mm. in diameter; strongly acid; clear wavy boundary.  (4 to 10 inches thick)"
       },
       {
-        "name": "22",
-        "top": 81,
+        "name": "Bt2",
+        "top": 56,
+        "bottom": 81,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 1,
         "narrative": "Bt2--22-32 inches, mottled gray (10YR 6/1), dark red (2.5YR 3/6),"
       },
       {
-        "name": "32",
-        "top": 122,
+        "name": "Bt3",
+        "top": 81,
+        "bottom": 122,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 2,
@@ -128,8 +133,9 @@
         "narrative": "Bt3--32-48 inches, light brownish gray (10YR 6/2) clay; many medium and coarse prominent red (10R 4/8) and few fine distinct reddish yellow mottles; moderate fine and medium subangular blocky structure; very hard, very firm; common fine and medium roots in the gray; common fine pores; thin patchy clay films on faces of peds; about 4 percent plinthite; center of a few of the red mottles have fine concretions; very strongly acid; clear smooth boundary.  (10 to 20 inches thick)"
       },
       {
-        "name": "48",
-        "top": 155,
+        "name": "Bt4",
+        "top": 122,
+        "bottom": 155,
         "moist_hue": "2.5Y",
         "moist_value": 7,
         "moist_chroma": 2,
@@ -140,8 +146,9 @@
         "narrative": "Bt4--48-61 inches, light gray (2.5Y 7/2) clay; common medium prominent dark red (10R 3/6) and common medium distinct reddish yellow (7.5YR 6/8) mottles; moderate fine subangular blocky structure; very hard, very firm; common fine and medium roots in the gray; few fine pores; thin patchy clay films on faces of peds; few nodules of plinthite; common fine and medium shiny faces and slickensides; very strongly acid; clear smooth boundary.  (10 to 15 inches thick)"
       },
       {
-        "name": "61",
-        "top": 183,
+        "name": "Bt5",
+        "top": 155,
+        "bottom": 183,
         "moist_hue": "2.5Y",
         "moist_value": 7,
         "moist_chroma": 2,

--- a/inst/extdata/OSD/I/INDUS.json
+++ b/inst/extdata/OSD/I/INDUS.json
@@ -170,7 +170,6 @@
       },
       {
         "name": "0a",
-        "top": 1,
         "moist_hue": "5YR",
         "moist_value": 2,
         "moist_chroma": 1,

--- a/inst/extdata/OSD/I/ISHKOTEN.json
+++ b/inst/extdata/OSD/I/ISHKOTEN.json
@@ -144,8 +144,9 @@
         "narrative": "Bt3--56 to 86 cm; strong brown (7.5YR 5/6) sandy clay loam, strong brown (7.5YR 4/6) moist; moderate medium angular blocky structure; hard, firm, moderately sticky and moderately plastic; common fine, medium, and coarse roots; common very fine tubular pores; common distinct clay films on ped faces; slightly acid (pH 6.4); gradual smooth boundary."
       },
       {
-        "name": "86",
-        "top": 122,
+        "name": "Cr",
+        "top": 86,
+        "bottom": 122,
         "texture_class": "sand",
         "narrative": "Cr--86-122 cm; weakly cemented sandstone with faint clay films in cracks"
       }

--- a/inst/extdata/OSD/J/JENKINS.json
+++ b/inst/extdata/OSD/J/JENKINS.json
@@ -144,6 +144,11 @@
         "bottom": 89,
         "texture_class": "sand",
         "narrative": "R--28 to 35 inches; interbedded sandstone and hard shale."
+      },
+      {
+        "name": "01",
+        "top": 5,
+        "narrative": "01--2 to inch; undecomposed organic material, mainly bark, twigs, and needles."
       }
     ]
   ]

--- a/inst/extdata/OSD/J/JUDY.json
+++ b/inst/extdata/OSD/J/JUDY.json
@@ -125,8 +125,9 @@
         "narrative": "BCk--22 to 28 inches; yellowish-brown (10YR 5/4) heavy silty clay loam, dark yellowish-brown (10YR 4/4) moist; medium fine angular and subangular blocky structure; hard, friable; thin patchy clay films on faces of peds; 5 percent limestone pebbles and flagstones; secondary calcium carbonate principally on the underside of the rock fragments; moderately alkaline (pH 8.2); gradual wavy boundary.  (3 to 12 inches thick)"
       },
       {
-        "name": "28",
-        "top": 102,
+        "name": "R",
+        "top": 71,
+        "bottom": 102,
         "narrative": "R--28-40 inches; Fractured limestone bedrock containing less than 5 percent fine material."
       }
     ]

--- a/inst/extdata/OSD/J/JUGTOWN.json
+++ b/inst/extdata/OSD/J/JUGTOWN.json
@@ -65,6 +65,84 @@
     ]
   ],
   "HORIZONS": [
-    {}
+    [
+      {
+        "name": "Ap1",
+        "top": 0,
+        "bottom": 18,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 2,
+        "texture_class": "silt loam",
+        "pH_class": "neutral",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "Ap1=0 to 7 inches; dark grayish brown (10YR 4/2) and brown (10YR 5/3) silt loam; moderate fine and medium granular structure; friable, nonsticky and nonplastic; common very fine and fine roots throughout; neutral; clear wavy boundary."
+      },
+      {
+        "name": "Ap2",
+        "top": 18,
+        "bottom": 30,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 2,
+        "texture_class": "silt loam",
+        "pH_class": "neutral",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "Ap2=7 to 12 inches; grayish brown (10YR 5/2) and yellowish brown (10YR 5/4) silt loam; moderate medium granular and moderate fine and medium subangular blocky structure; friable, nonsticky and nonplastic; common very fine and fine roots throughout; few fine and medium irregular very dark gray (10YR 3/1) dark concretions; neutral; clear wavy boundary."
+      },
+      {
+        "name": "BA",
+        "top": 30,
+        "bottom": 46,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 3,
+        "texture_class": "clay loam",
+        "pH_class": "mildly alkaline",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "BA=12 to 18 inches; brown (10YR 4/3) and yellowish brown (10YR 5/4) clay loam; yellowish brown (10YR 5/6) mottles; moderate medium subangular blocky structure; friable, slightly sticky and nonplastic; common very fine and fine roots throughout; few fine and medium irregular very dark gray (10YR 3/1) dark concretions; mildly alkaline; clear wavy boundary."
+      },
+      {
+        "name": "Bt1",
+        "top": 46,
+        "bottom": 66,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 4,
+        "texture_class": "clay loam",
+        "pH_class": "mildly alkaline",
+        "distinctness": "gradual",
+        "topography": "wavy",
+        "narrative": "Bt1=18 to 26 inches; dark yellowish brown (10YR 4/4) and yellowish brown (10YR 5/4) clay loam; moderate medium and coarse subangular blocky structure; friable, slightly sticky and slightly plastic; few very fine roots throughout; common distinct clay films on faces of peds; common fine and medium irregular very dark gray (10YR 3/1) dark concretions; 1 percent gravel; mildly alkaline; gradual wavy boundary."
+      },
+      {
+        "name": "Bt2",
+        "top": 71,
+        "bottom": 97,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 2,
+        "texture_class": "clay loam",
+        "pH_class": "mildly alkaline",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "Bt2=28 to 38 inches; grayish brown (10YR 5/2) clay loam; moderate medium and coarse subangular blocky structure; friable, slightly sticky and slightly plastic; few very fine roots throughout; common distinct clay films on faces of peds; common medium irregular black (10YR 2/1) dark concretions; common fine and medium prominent yellowish brown (10YR 5/6) iron concentrations; 4 percent gravel; mildly alkaline; clear wavy boundary."
+      },
+      {
+        "name": "C",
+        "top": 97,
+        "bottom": 165,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 4,
+        "texture_class": "sandy clay loam",
+        "cf_class": "very gravelly",
+        "pH_class": "mildly alkaline",
+        "narrative": "C=38 to 65 inches; yellowish brown (10YR 5/4) very gravelly sandy clay loam; massive; firm, slightly sticky and slightly plastic; few very fine roots throughout; common medium prominent yellowish brown (10YR 5/8) iron concentrations and common medium distinct grayish brown (10YR 5/2) iron depletions; 60 percent gravel and cobbles; mildly alkaline."
+      }
+    ]
   ]
 }

--- a/inst/extdata/OSD/K/KEERINS.json
+++ b/inst/extdata/OSD/K/KEERINS.json
@@ -119,6 +119,29 @@
         "narrative": "Btk1--8 to 11 inches; brown (10YR 4/3) extremely channery sandy clay loam, dark brown (10YR 3/3) moist; moderate very fine subangular blocky structure; very hard, friable, moderately sticky and moderately plastic; common very fine, fine and medium roots; common very fine and fine dendritic tubular pores; common faint patchy clay films on faces of peds, rock fragments and lining pores; finely disseminated carbonates throughout; 60 percent channers, 25 percent flagstones; violently effervescent; slightly alkaline (pH 7.8); clear wavy boundary. (2 to 5 inches thick)"
       },
       {
+        "name": "Btk2",
+        "top": 28,
+        "dry_hue": "10YR",
+        "dry_value": 5,
+        "dry_chroma": 1,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 3,
+        "texture_class": "sandy clay loam",
+        "cf_class": "extremely channery",
+        "pH": 7.6,
+        "pH_class": "slightly alkaline",
+        "distinctness": "clear",
+        "topography": "irregular",
+        "narrative": "Btk2--11 to16 inches; gray (10YR 5/1) extremely channery sandy clay loam, brown (10YR 4/3) moist; very fine and fine granular structure; loose, moderately sticky and moderately plastic; very few very fine roots; many very fine interstitial pores; common clay films lining interstitial pores and on rock fragments; finely disseminated carbonates throughout; 50 percent channers and 30 percent flagstone; violently effervescent slightly alkaline (pH 7.6); clear irregular boundary. (4 to 6 inches thick)"
+      },
+      {
+        "name": "Cr",
+        "top": 41,
+        "texture_class": "sand",
+        "narrative": "Cr--16 to18 inches; fractured moderately cemented calcareous sandstone. (1 to 10 inches thick)"
+      },
+      {
         "name": "R",
         "top": 46,
         "texture_class": "sand",

--- a/inst/extdata/OSD/K/KEMP.json
+++ b/inst/extdata/OSD/K/KEMP.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 46,
+        "name": "A1",
+        "top": 0,
+        "bottom": 46,
         "dry_hue": "10YR",
         "dry_value": 5,
         "dry_chroma": 3,
@@ -74,8 +75,9 @@
         "narrative": "A1    --  0-18 inches, brown (10YR 5/3) loam, dark brown"
       },
       {
-        "name": "18",
-        "top": 81,
+        "name": "C",
+        "top": 46,
+        "bottom": 81,
         "dry_hue": "10YR",
         "dry_value": 5,
         "dry_chroma": 2,
@@ -89,8 +91,9 @@
         "narrative": "C     --  18-32 inches, grayish brown (10YR 5/2) loam, dark grayish brown (10YR 4/2) moist; weak medium subangular blocky structure; hard, friable; many roots, common pores, and wormcasts; few thin strata of fine sandy loam; slightly acid; gradual smooth boundary.  (10 to 22 inches thick)"
       },
       {
-        "name": "32",
-        "top": 94,
+        "name": "Ab",
+        "top": 81,
+        "bottom": 94,
         "dry_hue": "10YR",
         "dry_value": 5,
         "dry_chroma": 2,
@@ -104,8 +107,9 @@
         "narrative": "Ab    --  32-37 inches, grayish brown (10YR 5/2) fine sandy loam, dark grayish brown (10YR 4/2) moist; few fine faint and distinct mottles of very dark gray, light brownish gray, and olive brown; weak medium subangular blocky structure; hard, friable; few roots, few pores, and worm casts; slightly acid; clear smooth boundary.  (0 to 14 inches thick)"
       },
       {
-        "name": "37",
-        "top": 132,
+        "name": "B2tb",
+        "top": 94,
+        "bottom": 132,
         "dry_hue": "10YR",
         "dry_value": 4,
         "dry_chroma": 1,
@@ -116,8 +120,9 @@
         "narrative": "B2tb  --  37-52 inches, dark gray (10YR 4/1) sandy clay loam, very dark gray (10YR 3/1) moist; few to common fine distinct"
       },
       {
-        "name": "52",
-        "top": 165,
+        "name": "B3b",
+        "top": 132,
+        "bottom": 165,
         "narrative": "B3b   --  52-65 inches, distinctly mottled strong brown"
       }
     ]

--- a/inst/extdata/OSD/K/KIBESILLAH.json
+++ b/inst/extdata/OSD/K/KIBESILLAH.json
@@ -147,7 +147,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; litter of Douglas fir, redwood and tanoak."
       }
     ]

--- a/inst/extdata/OSD/K/KLASI.json
+++ b/inst/extdata/OSD/K/KLASI.json
@@ -67,6 +67,17 @@
   "HORIZONS": [
     [
       {
+        "name": "Oi",
+        "top": 0,
+        "bottom": 13,
+        "moist_hue": "2.5YR",
+        "moist_value": 2.5,
+        "moist_chroma": 2,
+        "distinctness": "abrupt",
+        "topography": "irregular",
+        "narrative": "Oi=0 to 5 inches; very dusky red (2.5YR 2.5/2) peat; slightly decomposed moss and root fibers; abrupt irregular boundary.  (5 to 8 inches thick)"
+      },
+      {
         "name": "A",
         "top": 20,
         "bottom": 25,

--- a/inst/extdata/OSD/L/LAVATOP.json
+++ b/inst/extdata/OSD/L/LAVATOP.json
@@ -125,7 +125,6 @@
       },
       {
         "name": "R",
-        "top": 65,
         "narrative": "R--25.5 inches, (66 cm); fractured indurated basalt."
       }
     ]

--- a/inst/extdata/OSD/L/LELA.json
+++ b/inst/extdata/OSD/L/LELA.json
@@ -81,6 +81,20 @@
         "narrative": "Ap--0 to 15 cm (0 to 6 in); dark reddish brown (5YR 3/2) crushed silty clay; dark reddish brown (5YR 2/2) crushed moist; moderate fine angular blocky structure parting to strong fine granular; very hard, firm; common fine roots; noneffervescent; moderately acid (pH 6.0); abrupt smooth boundary. (Thickness of the Ap horizon 0 to 25 cm [0 to 10 in])"
       },
       {
+        "name": "A",
+        "top": 15,
+        "bottom": 33,
+        "dry_hue": "5YR",
+        "dry_value": 3,
+        "dry_chroma": 2,
+        "texture_class": "silty clay",
+        "pH": 7,
+        "pH_class": "neutral",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "A--15  33 cm (6 to 13 in); dark reddish brown (5YR 3/2) crushed silty clay; dark reddish brown (5YR 2/2) crushed moist; strong very fine and fine angular blocky structure; very hard, very firm; few fine roots; few very fine and fine constricted tubular pores; noneffervescent; neutral (pH 7.0); clear wavy boundary. (Thickness of the A horizon is 10 to 30 cm [4 to 12 in])"
+      },
+      {
         "name": "Bss2",
         "top": 86,
         "bottom": 107,

--- a/inst/extdata/OSD/L/LETTIA.json
+++ b/inst/extdata/OSD/L/LETTIA.json
@@ -172,7 +172,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; partially decomposed fir needles, twigs, leaves and grasses."
       },
       {

--- a/inst/extdata/OSD/L/LIVAN.json
+++ b/inst/extdata/OSD/L/LIVAN.json
@@ -103,8 +103,9 @@
         "narrative": "C1--6 to 32 inches; pale brown (10YR 6/3) stratified very gravelly loamy sand and  gravelly sandy loam, brown (10YR 5/3) moist; single grained; loose, nonsticky and nonplastic; many very fine and common fine roots; common very fine and few fine continuous random irregular pores; 45 percent gravel strongly effervescent, calcium carbonate disseminated; slightly alkaline (pH 7.8); abrupt smooth boundary."
       },
       {
-        "name": "32",
-        "top": 152,
+        "name": "C2",
+        "top": 81,
+        "bottom": 152,
         "dry_hue": "10YR",
         "dry_value": 6,
         "dry_chroma": 3,

--- a/inst/extdata/OSD/L/LOMAPELONA.json
+++ b/inst/extdata/OSD/L/LOMAPELONA.json
@@ -129,6 +129,19 @@
         "distinctness": "gradual",
         "topography": "smooth",
         "narrative": "C3--25 to 39 inches; pale brown (10YR 6/3)very fine sandy loam, brown (10YR 5/3) moist; few fine distinct brown (7.5YR 4/3) iron redox depletions; massive; very friable, slightly hard, nonsticky and nonplastic; few very fine, fine, and medium roots; few fine tubular pores; violently effervescent; moderately alkaline; gradual smooth boundary (6 to 18 inches thick)."
+      },
+      {
+        "name": "C4",
+        "top": 99,
+        "dry_hue": "10YR",
+        "dry_value": 7,
+        "dry_chroma": 3,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 3,
+        "texture_class": "fine sandy loam",
+        "pH_class": "moderately alkaline",
+        "narrative": "C4--39 to80 inches; very pale brown (10YR 7/3) fine sandy loam, brown (10YR 5/3) moist; few fine distinct brown (7.5YR 4/3), many medium prominent very dark brown (7.5YR 2.5/2), and few fine faint yellow (10YR 7/6) iron manganese redox depletions; massive; very friable, slightly hard, nonsticky and nonplastic; few very fine, fine, and medium roots; common very fine, few fine and medium tubular pores; few thin stratified clay lenses; violently effervescent; moderately alkaline."
       }
     ]
   ]

--- a/inst/extdata/OSD/M/MALSTROM.json
+++ b/inst/extdata/OSD/M/MALSTROM.json
@@ -127,6 +127,21 @@
         "texture_class": "fine sandy loam",
         "pH_class": "strongly alkaline",
         "narrative": "BCk--53 to 60 inches; very pale brown (10YR 8/3) fine sandy loam, very pale brown (10YR 7/3) moist; massive; very friable, slightly sticky, slightly plastic; few caliche pebbles; strongly calcareous; strongly alkaline."
+      },
+      {
+        "name": "Bk2",
+        "top": 64,
+        "dry_hue": "10YR",
+        "dry_value": 8,
+        "dry_chroma": 3,
+        "moist_hue": "10YR",
+        "moist_value": 7,
+        "moist_chroma": 3,
+        "texture_class": "loam",
+        "pH_class": "strongly alkaline",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "Bk2--25 to53 inches; very pale brown (10YR 8/3) loam, very pale brown (10YR 7/3) moist; massive; hard, very friable, slightly sticky, slightly plastic; many very fine tubular pores; disseminated calcium carbonate and few filaments of calcium carbonate; strongly calcareous; strongly alkaline; clear wavy boundary. (10 to 30 inches thick)"
       }
     ]
   ]

--- a/inst/extdata/OSD/M/MARCY.json
+++ b/inst/extdata/OSD/M/MARCY.json
@@ -10,8 +10,8 @@
     "content": "TAXONOMIC CLASS: Fine-loamy, mixed, frigid Typic Fragiaquepts"
   },
   "TYPICAL PEDON": {
-    "section": "TYPICAL PEDON",
-    "content": null
+    "section": "TYPIC PEDON",
+    "content": "TYPIC PEDON:  Marcy silt loam, on a 2 percent slope in a  grass meadow.  (Colors are for moist soil.)\nAp--0 to 7 inches; very dark gray (10YR 3/1) silt loam; moderate medium granular structure; friable; many roots; 5 percent rock fragments; moderately acid; abrupt smooth boundary.  (5 to 12 inches thick)\nBg--7 to 13 inches; grayish brown (2.5Y 5/2) silt loam;  many (30 percent) medium and fine distinct yellowish brown (10YR 5/6) mottles; very weak fine subangular blocky structure; friable; common fine roots; common fine pores; 10 percent rock fragments; moderately acid; clear wavy boundary.  (4 to 8 inches thick)\nBxg--13 to 40 inches; dark grayish brown (2.5Y 4/2) channery silt loam; common fine faint olive brown (2.5Y 4/4)  and gray (10YR 5/1) mottles increasing with depth; moderate very coarse prismatic structure increasing in size with depth; prisms 8 to 15 inches across; very firm; brittle; common fine pores with clay linings; prism faces coated with silt and very fine sand; 25 percent rock fragments; slightly acid grading to neutral at the bottom of the horizon; diffuse wavy boundary.\nCdg--40 to 72 inches; dark grayish brown (2.5Y 4/2) channery silt loam; common fine faint gray (10YR 5/1) mottles; weak thick platy structure; firm; 30 percent rock  fragment; neutral."
   },
   "TYPE LOCATION": {
     "section": "TYPE LOCATION",
@@ -65,6 +65,59 @@
     ]
   ],
   "HORIZONS": [
-    {}
+    [
+      {
+        "name": "Ap",
+        "top": 0,
+        "bottom": 18,
+        "moist_hue": "10YR",
+        "moist_value": 3,
+        "moist_chroma": 1,
+        "texture_class": "silt loam",
+        "pH_class": "moderately acid",
+        "distinctness": "abrupt",
+        "topography": "smooth",
+        "narrative": "Ap--0 to 7 inches; very dark gray (10YR 3/1) silt loam; moderate medium granular structure; friable; many roots; 5 percent rock fragments; moderately acid; abrupt smooth boundary.  (5 to 12 inches thick)"
+      },
+      {
+        "name": "Bg",
+        "top": 18,
+        "bottom": 33,
+        "moist_hue": "2.5Y",
+        "moist_value": 5,
+        "moist_chroma": 2,
+        "texture_class": "silt loam",
+        "pH_class": "moderately acid",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "Bg--7 to 13 inches; grayish brown (2.5Y 5/2) silt loam;  many (30 percent) medium and fine distinct yellowish brown (10YR 5/6) mottles; very weak fine subangular blocky structure; friable; common fine roots; common fine pores; 10 percent rock fragments; moderately acid; clear wavy boundary.  (4 to 8 inches thick)"
+      },
+      {
+        "name": "Bxg",
+        "top": 33,
+        "bottom": 102,
+        "moist_hue": "2.5Y",
+        "moist_value": 4,
+        "moist_chroma": 2,
+        "texture_class": "very fine sand",
+        "cf_class": "channery",
+        "pH_class": "slightly acid",
+        "distinctness": "diffuse",
+        "topography": "wavy",
+        "narrative": "Bxg--13 to 40 inches; dark grayish brown (2.5Y 4/2) channery silt loam; common fine faint olive brown (2.5Y 4/4)  and gray (10YR 5/1) mottles increasing with depth; moderate very coarse prismatic structure increasing in size with depth; prisms 8 to 15 inches across; very firm; brittle; common fine pores with clay linings; prism faces coated with silt and very fine sand; 25 percent rock fragments; slightly acid grading to neutral at the bottom of the horizon; diffuse wavy boundary."
+      },
+      {
+        "name": "Cdg",
+        "top": 102,
+        "bottom": 183,
+        "moist_hue": "2.5Y",
+        "moist_value": 4,
+        "moist_chroma": 2,
+        "texture_class": "silt loam",
+        "cf_class": "channery",
+        "pH_class": "neutral",
+        "narrative": "Cdg--40 to 72 inches; dark grayish brown (2.5Y 4/2) channery silt loam; common fine faint gray (10YR 5/1) mottles; weak thick platy structure; firm; 30 percent rock  fragment; neutral."
+      }
+    ]
   ]
 }

--- a/inst/extdata/OSD/M/MASCAMP.json
+++ b/inst/extdata/OSD/M/MASCAMP.json
@@ -119,6 +119,14 @@
         "distinctness": "abrupt",
         "topography": "smooth",
         "narrative": "Bt--33 to 48 cm; brown (10YR 5/3) extremely gravelly clay loam, brown (10YR 4/3) moist; moderate medium subangular blocky structure; hard, friable, moderately sticky and moderately plastic; many very fine and few fine roots; many very fine and fine tubular pores; 60 percent gravel; common faint clay films on faces of peds and many faint clay films in pores; neutral (pH 6.6); abrupt smooth boundary. (8 to 30 cm thick)"
+      },
+      {
+        "name": "R",
+        "top": 48,
+        "dry_hue": "5Y",
+        "dry_value": 7,
+        "dry_chroma": 1,
+        "narrative": "R--48 to cm; light gray (5Y 7/1) carbonate coated fractured tuff bedrock"
       }
     ]
   ]

--- a/inst/extdata/OSD/M/MATTAMUSKEET.json
+++ b/inst/extdata/OSD/M/MATTAMUSKEET.json
@@ -67,8 +67,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 15,
+        "name": "Oap",
+        "top": 0,
+        "bottom": 15,
         "texture_class": "sand",
         "pH_class": "strongly acid",
         "distinctness": "clear",
@@ -76,16 +77,18 @@
         "narrative": "Oap  --  0-6 inches, black (N 2/ , broken face and rubbed) sapric material; about 10 percent fibers, less than 1 percent rubbed; moderate medium granular structure; very friable; common fine and medium fibrous roots; common medium and coarse hard, subangular blocky fragments of organic material on the surface; few fine and medium fragments of charcoal and wood; common coated and clean sand grains; about 25 percent mineral content; strongly acid; clear smooth boundary.  (4 to 7 inches thick)"
       },
       {
-        "name": "6",
-        "top": 36,
+        "name": "Oa2",
+        "top": 15,
+        "bottom": 36,
         "pH_class": "extremely acid",
         "distinctness": "clear",
         "topography": "smooth",
         "narrative": "Oa2  --  6-14 inches, dusky red (2.5YR 3/2, broken face and rubbed) sapric material; about 25 percent fiber, less than 1 percent rubbed; weak medium subangular blocky structure; friable; sapric material is paste-like or greasy feeling (colloidal) when wet; common coarse roots, logs, and fragments of wood; extremely acid; clear smooth boundary.  (4 to 12 inches thick)"
       },
       {
-        "name": "14",
-        "top": 46,
+        "name": "Oa3",
+        "top": 36,
+        "bottom": 46,
         "texture_class": "sand",
         "pH_class": "extremely acid",
         "distinctness": "gradual",
@@ -93,8 +96,9 @@
         "narrative": "Oa3   --  14-18 inches, very dusky red (2.5YR 2/2, broken face and rubbed) sapric material; about 25 percent fibers, less than 1 percent rubbed; massive; friable; sticky; sapric material is paste-like or greasy feeling (colloidal); common coarse roots, logs, and fragments of wood; few coated and clean sand grains; extremely acid; gradual smooth boundary.  (4 to 20 inches thick)"
       },
       {
-        "name": "18",
-        "top": 56,
+        "name": "Oa4",
+        "top": 46,
+        "bottom": 56,
         "texture_class": "sand",
         "pH_class": "extremely acid",
         "distinctness": "abrupt",
@@ -102,8 +106,9 @@
         "narrative": "Oa4    --  18-22 inches, dark reddish brown (5YR 3/2, broken face and rubbed) sapric material; about 20 percent fibers, less than 1 percent rubbed; massive; friable; sticky; sapric material is paste-like or greasy feeling (colloidal); common coarse roots, logs, and fragments of wood; few coated and clean sand grains; extremely acid; abrupt wavy boundary.  (4 to 12 inches thick)"
       },
       {
-        "name": "22",
-        "top": 69,
+        "name": "2Abg",
+        "top": 56,
+        "bottom": 69,
         "moist_hue": "5YR",
         "moist_value": 3,
         "moist_chroma": 1,
@@ -113,8 +118,9 @@
         "narrative": "2Abg  --  22-27 inches, very dark gray (5YR 3/1) and dark reddish brown (5YR 2/2) sand; massive; very friable; about 15 percent sapric material; about 5 percent fibers, less than 1 percent rubbed; common fine and medium roots; abrupt wavy boundary.  (0 to 8 inches thick)"
       },
       {
-        "name": "27",
-        "top": 122,
+        "name": "2C1g",
+        "top": 69,
+        "bottom": 122,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 3,
@@ -125,8 +131,9 @@
         "narrative": "2C1g  --  27-48 inches, dark brown (10YR 4/3) sand with few pockets of very dark gray (10YR 3/2) loamy sand; massive; very friable; common fine and medium roots; extremely acid; gradual smooth boundary. 2"
       },
       {
-        "name": "48",
-        "top": 137,
+        "name": "C2g",
+        "top": 122,
+        "bottom": 137,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 3,
@@ -137,8 +144,9 @@
         "narrative": "C2g  --  48-54 inches, dark brown (10YR 4/3) sand; single grained; loose; extremely acid; clear smooth boundary."
       },
       {
-        "name": "54",
-        "top": 155,
+        "name": "3C3g",
+        "top": 137,
+        "bottom": 155,
         "moist_hue": "5Y",
         "moist_value": 4,
         "moist_chroma": 1,
@@ -149,8 +157,9 @@
         "narrative": "3C3g --  54-61 inches, dark gray (5Y 4/1) sandy loam and pockets of dark greenish gray (5GY 4/1) sandy clay loam massive; very friable, slightly sticky, slightly plastic; extremely acid; clear smooth boundary."
       },
       {
-        "name": "61",
-        "top": 183,
+        "name": "4C4g",
+        "top": 155,
+        "bottom": 183,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 3,

--- a/inst/extdata/OSD/M/MAU.json
+++ b/inst/extdata/OSD/M/MAU.json
@@ -119,6 +119,14 @@
         "distinctness": "abrupt",
         "topography": "smooth",
         "narrative": "Bt--33 to 48 cm; brown (10YR 5/3) extremely gravelly clay loam, brown (10YR 4/3) moist; moderate medium subangular blocky structure; hard, friable, moderately sticky and moderately plastic; many very fine and few fine roots; many very fine and fine tubular pores; 60 percent gravel; common faint clay films on faces of peds and many faint clay films in pores; neutral (pH 6.6); abrupt smooth boundary. (8 to 30 cm thick)"
+      },
+      {
+        "name": "R",
+        "top": 48,
+        "dry_hue": "5Y",
+        "dry_value": 7,
+        "dry_chroma": 1,
+        "narrative": "R--48 to cm; light gray (5Y 7/1) carbonate coated fractured tuff bedrock"
       }
     ]
   ]

--- a/inst/extdata/OSD/M/MCCRORY.json
+++ b/inst/extdata/OSD/M/MCCRORY.json
@@ -156,8 +156,9 @@
         "narrative": "C2 - 83 to 98 inches; pale brown (10YR 6/3) and brown (10YR 5/3) fine sand; structureless, single-grain; friable; few iron-manganese coatings on sand grains; common coarse faint grayish brown (10YR 5/2) iron depletions in matrix; slightly alkaline."
       },
       {
-        "name": "28",
-        "top": 91,
+        "name": "Btng2",
+        "top": 71,
+        "bottom": 91,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 2,
@@ -168,8 +169,9 @@
         "narrative": "Btng2 - 28-36 inches; grayish brown (10YR 5/2) fine sandy loam; weak coarse prismatic parting to weak medium subangular blocky structure; firm; few fine pores; few fine roots; few faint clay films on faces of some peds and lining some pores and root channls; common fine and medium distinct brown (10YR 4/3) and few fine distinct yellowish brown (10YR 5/6) iron accumulations; common medium black to brown hard iron-manganese concretions; moderately alkaline; clear smooth boundary."
       },
       {
-        "name": "36",
-        "top": 130,
+        "name": "Btng3",
+        "top": 91,
+        "bottom": 130,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 2,
@@ -180,8 +182,9 @@
         "narrative": "Btng3 - 36-51 inches; grayish brown (10YR 5/2) sandy clay loam; weak coarse prismatic parting to weak medium subangular blocky structure; firm; few fine pores; few fine roots; many distinct clay films on faces of some peds and lining some pores and root channels; few fine and medium distinct brown (10YR 4/3) and few fine distinct yellowish brown (10YR 5/6) iron accumulations; many fine and medium black (10YR 2/1) manganese accumulations on faces of peds and interiors of prisms; many medium black to brown hard iron-manganese concretions; strongly alkaline; clear smooth boundary."
       },
       {
-        "name": "51",
-        "top": 165,
+        "name": "Btng4",
+        "top": 130,
+        "bottom": 165,
         "moist_hue": "2.5Y",
         "moist_value": 5,
         "moist_chroma": 2,
@@ -192,8 +195,9 @@
         "narrative": "Btng4 - 51-65 inches; grayish brown (2.5Y 5/2) fine sandy loam; weak coarse subangular blocky structure; firm; common fine pores; few faint clay films on faces of some peds and lining some pores; few medium distinct brown (10YR 4/3) iron accumulations; common fine and medium black (10YR 2/1) manganese accumulations on faces of peds; few fine black to brown hard iron-manganese concretions; few fine and medium calcium carbonate concretions; strongly alkaline; gradual wavy boundary."
       },
       {
-        "name": "65",
-        "top": 178,
+        "name": "Btng5",
+        "top": 165,
+        "bottom": 178,
         "moist_hue": "2.5Y",
         "moist_value": 5,
         "moist_chroma": 2,

--- a/inst/extdata/OSD/M/MCGINNIS.json
+++ b/inst/extdata/OSD/M/MCGINNIS.json
@@ -140,7 +140,7 @@
       },
       {
         "name": "0",
-        "top": 1,
+        "bottom": 0,
         "narrative": "0--0.5 inch to 0; needles, leaves and twigs."
       },
       {

--- a/inst/extdata/OSD/M/MCNAB.json
+++ b/inst/extdata/OSD/M/MCNAB.json
@@ -134,7 +134,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; partially decomposed needles and twigs."
       }
     ]

--- a/inst/extdata/OSD/M/MIDDLEHILL.json
+++ b/inst/extdata/OSD/M/MIDDLEHILL.json
@@ -67,6 +67,21 @@
   "HORIZONS": [
     [
       {
+        "name": "A",
+        "top": 0,
+        "bottom": 8,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 3,
+        "texture_class": "sandy loam",
+        "cf_class": "extremely stony",
+        "pH": 7.2,
+        "pH_class": "neutral",
+        "distinctness": "abrupt",
+        "topography": "smooth",
+        "narrative": "A--0 8 cm; brown (10YR 5/3) extremely stony sandy loam, dark brown (10YR 3/3) moist; strong fine granular structure; soft, very friable, nonsticky and nonplastic; many very fine roots; many very fine irregular pores; 35 percent stones, 15 percent cobbles, and 30 percent gravel; neutral (pH 7.2); abrupt smooth boundary."
+      },
+      {
         "name": "AB",
         "top": 8,
         "bottom": 23,

--- a/inst/extdata/OSD/M/MULHOLLAND.json
+++ b/inst/extdata/OSD/M/MULHOLLAND.json
@@ -143,7 +143,6 @@
       },
       {
         "name": "Oe",
-        "top": 4,
         "distinctness": "abrupt",
         "topography": "smooth",
         "narrative": "Oe--1.5 inches to 0; loose, partially decomposed organic litter, including needles, leaves, twigs, bark chips, cones, and roots; abrupt smooth boundary.  (1 to 4 inches thick)"

--- a/inst/extdata/OSD/N/NATAPOC.json
+++ b/inst/extdata/OSD/N/NATAPOC.json
@@ -137,7 +137,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.25 inch to 0; undecomposed forest litter."
       }
     ]

--- a/inst/extdata/OSD/N/NEBEKER.json
+++ b/inst/extdata/OSD/N/NEBEKER.json
@@ -133,6 +133,21 @@
         "distinctness": "clear",
         "topography": "smooth",
         "narrative": "Bt3--48 to 55 inches; brown (7.5YR 5/4) clay, brown (7.5YR 4/3) moist; moderate medium prismatic structure that parts to moderate medium angular blocky structure; very hard, firm, sticky and plastic; common fine pores; many distinct clay films; neutral (pH 7.3); clear smooth boundary. (0 to 10 inches thick)"
+      },
+      {
+        "name": "2C",
+        "top": 140,
+        "bottom": 178,
+        "dry_hue": "10YR",
+        "dry_value": 5,
+        "dry_chroma": 3,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 3,
+        "texture_class": "clay loam",
+        "pH": 7.6,
+        "pH_class": "slightly alkaline",
+        "narrative": "2C--55 70 inches; brown (10YR 5/3) clay loam, brown (10YR 4/3) moist; massive; slightly hard, firm slightly sticky and plastic; slightly effervescent; slightly alkaline (pH 7.6)."
       }
     ]
   ]

--- a/inst/extdata/OSD/N/NESSEN.json
+++ b/inst/extdata/OSD/N/NESSEN.json
@@ -146,6 +146,21 @@
         "cf_class": "gravelly",
         "pH_class": "moderately alkaline",
         "narrative": "2C--112 to 203 cm (44 to 80 inches); yellowish brown (10YR 5/4) stratified sand (5 percent gravel) and gravelly sand (20 percent gravel); single grain; loose; few medium and coarse roots in the upper 30 cm (12 inches); slightly effervescent; moderately alkaline."
+      },
+      {
+        "name": "A",
+        "top": 0,
+        "dry_hue": "5YR",
+        "dry_value": 4,
+        "dry_chroma": 1,
+        "moist_hue": "5YR",
+        "moist_value": 2.5,
+        "moist_chroma": 1,
+        "texture_class": "sand",
+        "pH_class": "moderately acid",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "A--0 to10 cm (4 inches); black (5YR 2.5/1) sand, dark gray (5YR 4/1) dry; weak fine granular structure; very friable; many very fine and fine and common medium and coarse roots; about 5 percent gravel; moderately acid; clear wavy boundary. [2 to 13 cm (1 to 5 inches) thick]"
       }
     ]
   ]

--- a/inst/extdata/OSD/N/NEWOT.json
+++ b/inst/extdata/OSD/N/NEWOT.json
@@ -194,8 +194,9 @@
         "narrative": "Bt--38 to 57 inches; reddish brown (5YR 4/4) gravelly sandy loam; weak coarse prismatic structure parting to weak medium subangular blocky; firm; tends to part along horizontal cleavage planes inherited from the parent material; few fine roots; few faint dark reddish brown (5YR 3/4) clay films on faces of peds; common distinct brown (7.5YR 5/3) coatings of sand primarily on vertical faces of prisms; about 22 percent gravel and 3 percent cobbles; slight brittleness inherited from dense parent material; moderately acid; gradual wavy boundary. (0 to 25 inches thick)"
       },
       {
-        "name": "57",
-        "top": 152,
+        "name": "Cd",
+        "top": 145,
+        "bottom": 152,
         "moist_hue": "5YR",
         "moist_value": 4,
         "moist_chroma": 4,

--- a/inst/extdata/OSD/N/NINOT.json
+++ b/inst/extdata/OSD/N/NINOT.json
@@ -171,6 +171,23 @@
         "pH": 8.6,
         "pH_class": "strongly alkaline",
         "narrative": "Bk4--32 to 60 inches; light gray (10YR 7/2) gravelly loam, very pale brown (10YR 7/3) moist; massive; slightly hard, friable, slightly sticky and slightly plastic; 25 percent pebbles, 5 percent cobbles; 40 percent calcium carbonate equivalent; calcium carbonate disseminated; violently effervescent; strongly alkaline (pH 8.6)."
+      },
+      {
+        "name": "A1",
+        "top": 0,
+        "dry_hue": "10YR",
+        "dry_value": 5,
+        "dry_chroma": 3,
+        "moist_hue": "10YR",
+        "moist_value": 3,
+        "moist_chroma": 2,
+        "texture_class": "loam",
+        "cf_class": "very gravelly",
+        "pH": 8,
+        "pH_class": "moderately alkaline",
+        "distinctness": "abrupt",
+        "topography": "wavy",
+        "narrative": "A1--0 to3 inches; brown (10YR 5/3) very gravelly loam, very dark grayish brown (10YR 3/2) moist; moderate medium granular structure parting to weak fine granular; soft, very friable, slightly sticky and nonplastic; 40 percent pebbles, 5 percent cobbles; 1.3 percent calcium carbonate equivalent; strongly effervescent; moderately alkaline (pH 8.0); abrupt wavy boundary.  (2 to 4 inches thick)"
       }
     ]
   ]

--- a/inst/extdata/OSD/N/NORTON.json
+++ b/inst/extdata/OSD/N/NORTON.json
@@ -132,8 +132,9 @@
         "narrative": "IIC--63 to 70 inches, dark reddsh brown (2.5YR 3/4) shaly loam; mossive; 20 percent fragments of red shale 1/2 to several inches across, on coating surfaces; medium acid; gradual irregular boundary.  (0 to 15 inches thick)"
       },
       {
-        "name": "10",
-        "top": 36,
+        "name": "B1",
+        "top": 25,
+        "bottom": 36,
         "moist_hue": "2.5YR",
         "moist_value": 4,
         "moist_chroma": 2,

--- a/inst/extdata/OSD/O/OBSKEL.json
+++ b/inst/extdata/OSD/O/OBSKEL.json
@@ -165,7 +165,6 @@
       },
       {
         "name": "Cr",
-        "top": 141,
         "narrative": "Cr--55.5 inches, (141 cm); very weakly cemented metadiorite bedrock; roots are greater than 4 inches, (10 cm) apart, rock fractures are less than 4 inches, (10 cm) apart."
       }
     ]

--- a/inst/extdata/OSD/O/ORNBAUN.json
+++ b/inst/extdata/OSD/O/ORNBAUN.json
@@ -178,7 +178,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; litter of redwood and Douglas fir."
       }
     ]

--- a/inst/extdata/OSD/O/ORSET.json
+++ b/inst/extdata/OSD/O/ORSET.json
@@ -168,7 +168,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; fresh and partially decomposed needles, bark, grass blades, and other organic debris."
       }
     ]

--- a/inst/extdata/OSD/P/PACIFICO.json
+++ b/inst/extdata/OSD/P/PACIFICO.json
@@ -102,7 +102,7 @@
       },
       {
         "name": "0",
-        "top": 1,
+        "bottom": 0,
         "narrative": "0--0.5 inch to 0; oak and conifer leaf and needle litter."
       },
       {

--- a/inst/extdata/OSD/P/PASAGSHAK.json
+++ b/inst/extdata/OSD/P/PASAGSHAK.json
@@ -130,8 +130,9 @@
         "narrative": "Oe--1 inch to 0; very dark grayish brown (10YR 3/2) mat of partially decomposed leaves and straw; very strongly acid; abrupt smooth boundary.   (1 to 4 inches thick)"
       },
       {
-        "name": "10",
-        "top": 61,
+        "name": "4Cb",
+        "top": 25,
+        "bottom": 61,
         "moist_hue": "2.5Y",
         "moist_value": 3,
         "moist_chroma": 2,

--- a/inst/extdata/OSD/P/PEAKIN.json
+++ b/inst/extdata/OSD/P/PEAKIN.json
@@ -132,8 +132,9 @@
         "narrative": "BCt--53 to 63 inches; reddish brown (2.5YR 4/4) silt loam; weak coarse subangular blocky structure; friable; moderately sticky; plastic; few faint clay films on faces of peds; common medium prominent light gray (10YR 7/2) iron depletions; very strongly acid; gradual wavy boundary. (5 to 25 inches thick)"
       },
       {
-        "name": "63",
-        "top": 203,
+        "name": "C",
+        "top": 160,
+        "bottom": 203,
         "moist_hue": "2.5YR",
         "moist_value": 4,
         "moist_chroma": 4,

--- a/inst/extdata/OSD/P/PELELIU.json
+++ b/inst/extdata/OSD/P/PELELIU.json
@@ -99,7 +99,7 @@
       },
       {
         "name": "01",
-        "top": 1,
+        "bottom": 3,
         "narrative": "01--.4 inch to 0; undecomposed leaf litter and twigs.  (0 to 2 inches thick)"
       },
       {

--- a/inst/extdata/OSD/P/PHIPPS.json
+++ b/inst/extdata/OSD/P/PHIPPS.json
@@ -149,7 +149,7 @@
       },
       {
         "name": "02",
-        "top": 1,
+        "bottom": 5,
         "narrative": "02--0.5 inch to 0; a discontinuous surface layer of decomposed organic material."
       }
     ]

--- a/inst/extdata/OSD/P/PINOLE.json
+++ b/inst/extdata/OSD/P/PINOLE.json
@@ -129,7 +129,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; roots and decomposed grass material."
       }
     ]

--- a/inst/extdata/OSD/P/PINONES.json
+++ b/inst/extdata/OSD/P/PINONES.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 10,
+        "name": "Ap",
+        "top": 0,
+        "bottom": 10,
         "moist_hue": "10YR",
         "moist_value": 3,
         "moist_chroma": 2,
@@ -77,8 +78,9 @@
         "narrative": "Ap--0-4 inches; Very dark grayish brown (10YR 3/2) silty clay; common medium distinct yellowish brown (10YR 5/8) mottles; weak fine subangular blocky structure; friable, slightly sticky, plastic, many fine roots; very strongly acid; clear smooth boundary.  (7 to 12 inches thick)"
       },
       {
-        "name": "4",
-        "top": 33,
+        "name": "B21g",
+        "top": 10,
+        "bottom": 33,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 1,
@@ -89,8 +91,9 @@
         "narrative": "B21g--4-13 inches; Dark gray (10YR 4/1) silty clay; common medium distinct yellowish brown (10YR 5/6) mottles; weak medium subangular blocky structure; firm, slightly sticky, plastic, common fine roots; very strongly acid; clear smooth boundary.  (7 to 12 inches thick)"
       },
       {
-        "name": "13",
-        "top": 46,
+        "name": "B22g",
+        "top": 33,
+        "bottom": 46,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 1,
@@ -101,8 +104,9 @@
         "narrative": "B22g--13-18 inches; Dark gray (10YR 4/1) silty clay; many coarse distinct yellowish brown (10YR 5/6) mottles; weak medium subangular blocky structure firm, slightly sticky, plastic; few fine roots; very strongly acid; clear smooth boundary. (4 to 8 inches thick)"
       },
       {
-        "name": "18",
-        "top": 147,
+        "name": "11C",
+        "top": 46,
+        "bottom": 147,
         "moist_hue": "5YR",
         "moist_value": 3,
         "moist_chroma": 2,

--- a/inst/extdata/OSD/P/POTTER.json
+++ b/inst/extdata/OSD/P/POTTER.json
@@ -150,6 +150,21 @@
         "distinctness": "diffuse",
         "topography": "wavy",
         "narrative": "BCkk2--74 to 140 cm (29 to 55 in); white (10YR 8/1) extremely gravelly fine sandy loam, light gray (10YR 7/2) moist; 61 percent by volume of very strongly cemented, thick platy calcrete fragments and nodules, 2.5 to 15 cm (1 to 6 in) on the long axis, plates are fractured and common oxide stains on undersides of pendants and plates; 26 percent of the volume is carbonate masses and loamy soil material; few fine and medium roots mainly of woody plants between fractured plates; violently effervescent; strongly alkaline; diffuse wavy boundary. (51 to 76 cm [20 to 30 in] thick)."
+      },
+      {
+        "name": "BCkk3",
+        "top": 140,
+        "bottom": 203,
+        "dry_hue": "10YR",
+        "dry_value": 8,
+        "dry_chroma": 1,
+        "moist_hue": "10YR",
+        "moist_value": 7,
+        "moist_chroma": 2,
+        "texture_class": "fine sandy loam",
+        "cf_class": "extremely gravelly",
+        "pH_class": "strongly alkaline",
+        "narrative": "BCkk3--140 203 cm (55 to 80 in); white (10YR 8/1) extremely gravelly fine sandy loam, light gray (10YR 7/2) moist; 63 percent by volume of very strongly cemented, thick platy calcrete fragments and nodules, 2.5 to 15 cm (1 to 6 in) on the long axis, plates are fractured and common oxide stains on undersides of pendants and plates; 23 percent of the volume is carbonate masses and loamy soil material; few fine and medium roots mainly of woody plants between fractured plates; violently effervescent; strongly alkaline."
       }
     ]
   ]

--- a/inst/extdata/OSD/P/PROW.json
+++ b/inst/extdata/OSD/P/PROW.json
@@ -71,8 +71,9 @@
         "narrative": "C2--18 to 22 inches; Soft, white marlstone."
       },
       {
-        "name": "0",
-        "top": 5,
+        "name": "A1",
+        "top": 0,
+        "bottom": 5,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 2,
@@ -85,8 +86,9 @@
         "narrative": "A1--0-2 inches; Light brownish gray (10YR 6/2) channery silty clay loam, dark grayish brown (10YR 4/2) moist; moderate very fine granular structure; slightly hard, very friable, sticky, plastic; many fine roots, few medium and coarse roots; 15 percent channery; calcareous; moderately alkaline (pH 8.4); clear smooth boundary. (2 to 4 inches thick)"
       },
       {
-        "name": "2",
-        "top": 46,
+        "name": "C1",
+        "top": 5,
+        "bottom": 46,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 3,

--- a/inst/extdata/OSD/P/PSYAM.json
+++ b/inst/extdata/OSD/P/PSYAM.json
@@ -158,8 +158,9 @@
         "narrative": "2Btg2--51 to 76 inches; light brownish gray (2.5Y 6/2) silty clay loam; weak medium and coarse subangular blocky structure; firm; few fine roots; common fine and few medium pores; many prominent gray (2.5Y 6/1) and light olive brown (2.5Y 5/3) clay films on faces of peds and along surfaces of pores; few fine and medium distinct light gray (10YR 7/1) clay depletions on faces of some peds; common medium and coarse prominent yellowish brown (10YR 5/6), and common fine and common medium faint light olive brown (2.5Y 5/3) masses of iron accumulation in matrix; common medium and coarse faint gray (2.5Y 6/1) iron depletions in matrix; common fine and medium black (10YR 2/1) masses of manganese accumulations on faces of peds and lining some pores; few fine and medium red to black iron-manganese concretions throughout; about 8% soft weathered shale channers up to 4\" in length; strongly acid; clear wavy boundary."
       },
       {
-        "name": "76",
-        "top": 203,
+        "name": "2Cr",
+        "top": 193,
+        "bottom": 203,
         "moist_hue": "2.5Y",
         "moist_value": 5,
         "moist_chroma": 3,

--- a/inst/extdata/OSD/Q/QUARTZVILLE.json
+++ b/inst/extdata/OSD/Q/QUARTZVILLE.json
@@ -184,6 +184,11 @@
         "pH": 5.2,
         "pH_class": "strongly acid",
         "narrative": "C--59 to 66 inches; yellowish brown (10YR 5/4 and 5/6) extremely paragravelly clay loam, light yellowish brown (10YR 6/4) and yellowish brown (10YR 5/4) dry; massive; slightly hard, friable, slightly sticky and slightly plastic; few very fine roots; common very fine tubular pores; 65 percent paragravel; strongly acid (pH 5.2)."
+      },
+      {
+        "name": "Oi",
+        "top": 0,
+        "narrative": "Oi--0 to1 inch; slightly decomposed litter of leaves, twigs, moss, and needles."
       }
     ]
   ]

--- a/inst/extdata/OSD/R/REPARADA.json
+++ b/inst/extdata/OSD/R/REPARADA.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 20,
+        "name": "Ap",
+        "top": 0,
+        "bottom": 20,
         "moist_hue": "10YR",
         "moist_value": 2,
         "moist_chroma": 2,
@@ -77,8 +78,9 @@
         "narrative": "Ap--0-8 inches; Very dark brown (10YR 2/2) clay; common medium distinct brown (7.5YR 4/4) and few medium distinct dark reddish brown (2.5YR 2/4) mottles; weak medium subangular blocky structure; firm, slightly sticky, slightly plastic; common fine roots; very dark gray (N 3/) coatings on ped surfaces; mildly alkaline; gradual smooth boundary.  (6 to 10 inches thick)"
       },
       {
-        "name": "8",
-        "top": 46,
+        "name": "B2g",
+        "top": 20,
+        "bottom": 46,
         "moist_hue": "5G",
         "moist_value": 4,
         "moist_chroma": 1,
@@ -89,8 +91,9 @@
         "narrative": "B2g--8-18 inches; Very dark gray (N 3/) clay; many coarse prominent dark greenish gray (5G 4/1) mottles; massive; firm, slightly sticky, slightly plastic; few fine roots; few partially decomposed plant residues; mildly alkaline; gradual smooth boundary.  (6 to 12 inches thick)"
       },
       {
-        "name": "18",
-        "top": 15,
+        "name": "110C",
+        "top": 46,
+        "bottom": 15,
         "moist_hue": "10YR",
         "moist_value": 2,
         "moist_chroma": 1,

--- a/inst/extdata/OSD/R/REVEL.json
+++ b/inst/extdata/OSD/R/REVEL.json
@@ -85,7 +85,6 @@
       },
       {
         "name": "Oa",
-        "top": 1,
         "narrative": "Oa--0.5 inch to 0; decomposed needles, leaves and twigs; many very fine and common fine roots."
       },
       {

--- a/inst/extdata/OSD/R/RIO_ARRIBA.json
+++ b/inst/extdata/OSD/R/RIO_ARRIBA.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 20,
+        "name": "Ap",
+        "top": 0,
+        "bottom": 20,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 3,
@@ -77,8 +78,9 @@
         "narrative": "Ap--0-8 inches; Brown (10YR 4/3) clay; weak coarse granular structure; hard, firm slightly sticky, plastic; many fine roots; neutral; clear smooth boundary.  (4 to 10 inches thick)"
       },
       {
-        "name": "8",
-        "top": 41,
+        "name": "B21t",
+        "top": 20,
+        "bottom": 41,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 8,
@@ -88,8 +90,9 @@
         "narrative": "B21t--8-16 inches; Yellowish brown (10YR 5/8) clay; moderate coarse prismatic breaking to weak medium subangular blocky structure with yellowish brown (10YR 5/4) thin continuous coatings on vertical surfaces of peds and patchy coatings on horizontal ped surfaces; hard, firm, slightly sticky, plastic; common fine roots; common fine black nodules; medium acid; clear smooth boundary.  (6 to 12 inches thick)"
       },
       {
-        "name": "16",
-        "top": 71,
+        "name": "B22t",
+        "top": 41,
+        "bottom": 71,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 6,
@@ -100,8 +103,9 @@
         "narrative": "B22t--16-28 inches; Yellowish brown (10YR 5/6) clay with common medium distinct yellowish red (5YR 4/6) mottles; weak coarse angular blocky with few slickensides and pressure faces; firm, slightly sticky, plastic, many fine black nodules; few fine roots; neutral; clear wavy boundary.  (10 to 20 inches thick)"
       },
       {
-        "name": "28",
-        "top": 152,
+        "name": "B23t",
+        "top": 71,
+        "bottom": 152,
         "moist_hue": "7.5YR",
         "moist_value": 6,
         "moist_chroma": 6,

--- a/inst/extdata/OSD/R/ROXTON.json
+++ b/inst/extdata/OSD/R/ROXTON.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 33,
+        "name": "A11",
+        "top": 0,
+        "bottom": 33,
         "moist_hue": "10YR",
         "moist_value": 3,
         "moist_chroma": 1,
@@ -74,8 +75,9 @@
         "narrative": "A11   --  0-13 inches, very dark gray (10YR 3/1) clay;"
       },
       {
-        "name": "13",
-        "top": 46,
+        "name": "A12",
+        "top": 33,
+        "bottom": 46,
         "moist_hue": "10YR",
         "moist_value": 3,
         "moist_chroma": 1,
@@ -83,8 +85,9 @@
         "narrative": "A12   --  13-18 inches, very dark gray (10YR 3/1) clay; few medium distinct dark yellowish brown (10YR 3/4) mottles; moderate fine and medium subangular blocky structure; extremely hard, very firm, very sticky and plastic; few fine and medium tree roots; few wormcasts; few discontinuous dark grayish brown loamy strata 1 to"
       },
       {
-        "name": "18",
-        "top": 74,
+        "name": "B21g",
+        "top": 46,
+        "bottom": 74,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 1,
@@ -92,8 +95,9 @@
         "narrative": "B21g  --  18-29 inches, dark gray (10YR 4/1) clay; common"
       },
       {
-        "name": "29",
-        "top": 109,
+        "name": "B22g",
+        "top": 74,
+        "bottom": 109,
         "moist_hue": "10YR",
         "moist_value": 4,
         "moist_chroma": 1,
@@ -104,8 +108,9 @@
         "narrative": "B22g  --  29-43 inches, mottled dark gray (10YR 4/1) and dark grayish brown (10YR 4/2) silty clay; common medium distinct dark yellowish brown (10YR 4/4) mottles; weak medium blocky structure parting to weak fine blocky structure; extremely hard, very firm, sticky and plastic; common fine, medium and large roots; few black concretions 1 to 3 mm in diameter; few black organic matter fragments; few thin lenses of brown loamy material; slightly acid; gradual smooth boundary.  (12 to 32 inches thick)"
       },
       {
-        "name": "43",
-        "top": 163,
+        "name": "ABG",
+        "top": 109,
+        "bottom": 163,
         "moist_hue": "10YR",
         "moist_value": 3,
         "moist_chroma": 1,

--- a/inst/extdata/OSD/S/SEHOME.json
+++ b/inst/extdata/OSD/S/SEHOME.json
@@ -151,7 +151,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; needles, leaves, twigs, moss."
       }
     ]

--- a/inst/extdata/OSD/S/SELDOM.json
+++ b/inst/extdata/OSD/S/SELDOM.json
@@ -115,6 +115,22 @@
         "narrative": "Bkg1--38 to 86 centimeters (15 to 34 inches); light brownish gray (10YR 6/2) sandy loam, grayish brown (10YR 5/2) moist; weak fine subangular blocky structure; very hard, friable, slightly sticky and slightly plastic; few fine roots; few fine masses of calcium carbonate; violently effervescent; few fine distinct yellowish brown (10YR 5/6) redoximorphic concentrations throughout; very strongly alkaline; clear smooth boundary. (28 to 48 centimeters (11 to 19 inches) thick)"
       },
       {
+        "name": "Bkg2",
+        "top": 86,
+        "bottom": 107,
+        "dry_hue": "10YR",
+        "dry_value": 8,
+        "dry_chroma": 1,
+        "moist_hue": "10YR",
+        "moist_value": 6,
+        "moist_chroma": 2,
+        "texture_class": "sandy loam",
+        "pH_class": "very strongly alkaline",
+        "distinctness": "gradual",
+        "topography": "smooth",
+        "narrative": "Bkg2--86 107 centimeters (34 to 42 inches); white (10YR 8/1) sandy loam, light brownish gray (10YR 6/2) moist; massive; very hard, friable, slightly sticky and slightly plastic; few fine roots; few fine masses of calcium carbonate; violently effervescent; few fine faint gray (10YR 6/1) redoximorphic depletions and few fine distinct yellowish brown (10YR 5/6) redoximorphic concentrations throughout; very strongly alkaline; gradual smooth boundary. (13 to 61 centimeters (5 to 24 inches) thick)"
+      },
+      {
         "name": "Bkg3",
         "top": 107,
         "bottom": 152,

--- a/inst/extdata/OSD/S/SHERBURNE.json
+++ b/inst/extdata/OSD/S/SHERBURNE.json
@@ -167,7 +167,6 @@
       },
       {
         "name": "E",
-        "top": 2,
         "dry_hue": "10YR",
         "dry_value": 7,
         "dry_chroma": 2,

--- a/inst/extdata/OSD/S/SHOESTRING.json
+++ b/inst/extdata/OSD/S/SHOESTRING.json
@@ -192,6 +192,11 @@
         "pH": 6.2,
         "pH_class": "slightly acid",
         "narrative": "4C2--35 to 63 inches; dark gray (10YR 4/1) very gravelly sand, gray (10YR 6/1) dry; single grain; loose; few fine roots; many medium and coarse irregular pores; 30 percent gravel, 10 percent cobbles, and 5 percent stones; slightly acid (pH 6.2)."
+      },
+      {
+        "name": "Oi",
+        "top": 0,
+        "narrative": "Oi--0 to1 inch; slightly decomposed plant material."
       }
     ]
   ]

--- a/inst/extdata/OSD/S/SKAMANIA.json
+++ b/inst/extdata/OSD/S/SKAMANIA.json
@@ -174,7 +174,6 @@
       },
       {
         "name": "Oa",
-        "top": 1,
         "narrative": "Oa--0.5 inch to 0; decomposed organic material."
       }
     ]

--- a/inst/extdata/OSD/S/SKATE.json
+++ b/inst/extdata/OSD/S/SKATE.json
@@ -120,7 +120,7 @@
       },
       {
         "name": "02",
-        "top": 9,
+        "bottom": 5,
         "distinctness": "abrupt",
         "topography": "smooth",
         "narrative": "0l and 02--3.5 inches to 0; loose, partially decomposed organic litter including needles, leaves, twigs, and bark chips; abrupt smooth boundary.  (l to 5 inches thick)"

--- a/inst/extdata/OSD/S/SNILEC.json
+++ b/inst/extdata/OSD/S/SNILEC.json
@@ -170,6 +170,11 @@
         "pH": 7.2,
         "pH_class": "neutral",
         "narrative": "2Bt4--53 to 61 inches; pale brown (10YR 6/3) extremely cobbly loam, brown (10YR 4/3) moist; moderate coarse subangular blocky structure parting to moderate medium subangular blocky; slightly hard, friable, slightly sticky and slightly plastic; few fine and very fine roots; common fine and very fine tubular pores; common faint brown (10YR 4/3) clay films lining pores and on faces of peds; 35 percent gravel, 30 percent cobbles and 5 percent stones; neutral (pH 7.2)."
+      },
+      {
+        "name": "Oi",
+        "top": 0,
+        "narrative": "Oi--0 to1 inch; slightly decomposed forest litter mixed with a small amount of 1980 Mt. St. Helens volcanic ash. (1 to 2 inches thick)"
       }
     ]
   ]

--- a/inst/extdata/OSD/S/SOUTHMOUNT.json
+++ b/inst/extdata/OSD/S/SOUTHMOUNT.json
@@ -10,8 +10,8 @@
     "content": "TAXONOMIC CLASS: Fine-loamy, mixed, superactive Pachic Argicryolls"
   },
   "TYPICAL PEDON": {
-    "section": "TYPICAL PEDON",
-    "content": null
+    "section": "TYPIC PEDON",
+    "content": "TYPIC PEDON:  Southmount silt loam -- on a northeast-facing slightly convex slope of 8 percent, under Douglas fir woodland, at 5,840 feet elevation.  (Colors are for air dry soil unless otherwise stated.  When described on August 17, l983, the soil was slightly moist from 0 to 117 cm and moist below.)\nOi--0 to 3 cm; partly decomposed needles and twigs.  (3 to 8 cm thick)\nA--3 to 16 cm; dark brown (10YR 3/3) silt loam, very dark brown (10YR 2/2) moist; weak fine and medium subangular blocky structure parting to moderate fine granular; slightly hard, very friable, slightly sticky and slightly plastic; common fine and very fine, few medium and coarse roots; common fine and very fine vesicular and interstitial pores; 10 percent gravel; neutral (pH 6.7); clear wavy boundary.  (13 to 38 cm thick)\nBt1--16 to 36 cm; dark brown (10YR 4/3) cobbly silt loam, very dark brown (10YR 2/2) moist; moderate fine and medium subangular blocky structure; slightly hard, very friable, slightly sticky and moderately plastic; many very fine, fine and medium, few coarse roots; common fine and very fine tubular pores; many faint clay films on faces of peds and lining pores; 10 percent gravel, 10 percent cobbles; moderately acid (pH 6.0); clear smooth boundary.  (18 to 48 cm thick)\nBt2--36 to 49 cm; brown (10YR 4/3) gravelly clay loam, dark brown (10YR 3/3) moist; moderate fine and medium subangular blocky structure; hard, friable, moderately sticky and moderately plastic; common very fine, fine and medium, few coarse roots; common fine and very fine tubular pores; many distinct clay films on faces of peds and lining pores; 10 percent gravel, 5 percent cobbles; strongly acid (pH 5.5); clear wavy boundary.  (13 to 43 cm thick)\n2Bt--49 to 110 cm; brownish yellow (10YR 6/6) gravelly clay loam, dark yellowish brown (10YR 4/6) moist, with few fine distinct mottles of strong brown (7.5YR 5/6); moderate medium angular blocky structure; hard, friable, slightly sticky and slightly plastic; few fine and very fine roots; common fine and very fine tubular pores; common faint clay films on faces of peds; trace manganese concretions; 20 percent gravel; strongly acid (pH 5.5); gradual irregular boundary.  (0 to 61 cm thick)\n2C--110 to 155 cm; light yellowish brown (2.5Y 6/4) sandy loam, olive brown (2.5Y 4/4) moist, with few medium prominent mottles of yellow (2.5Y 7/6); massive; very hard, friable, nonsticky and nonplastic; few fine and very fine tubular pores; trace manganese concretions; 5 percent gravel; strongly acid (pH 5.2)."
   },
   "TYPE LOCATION": {
     "section": "TYPE LOCATION",
@@ -65,6 +65,84 @@
     ]
   ],
   "HORIZONS": [
-    {}
+    [
+      {
+        "name": "Oi",
+        "top": 0,
+        "bottom": 3,
+        "narrative": "Oi--0 to 3 cm; partly decomposed needles and twigs.  (3 to 8 cm thick)"
+      },
+      {
+        "name": "A",
+        "top": 3,
+        "bottom": 16,
+        "moist_hue": "10YR",
+        "moist_value": 3,
+        "moist_chroma": 3,
+        "texture_class": "silt loam",
+        "pH": 6.7,
+        "pH_class": "neutral",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "A--3 to 16 cm; dark brown (10YR 3/3) silt loam, very dark brown (10YR 2/2) moist; weak fine and medium subangular blocky structure parting to moderate fine granular; slightly hard, very friable, slightly sticky and slightly plastic; common fine and very fine, few medium and coarse roots; common fine and very fine vesicular and interstitial pores; 10 percent gravel; neutral (pH 6.7); clear wavy boundary.  (13 to 38 cm thick)"
+      },
+      {
+        "name": "Bt1",
+        "top": 16,
+        "bottom": 36,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 3,
+        "texture_class": "silt loam",
+        "cf_class": "cobbly",
+        "pH": 6,
+        "pH_class": "moderately acid",
+        "distinctness": "clear",
+        "topography": "smooth",
+        "narrative": "Bt1--16 to 36 cm; dark brown (10YR 4/3) cobbly silt loam, very dark brown (10YR 2/2) moist; moderate fine and medium subangular blocky structure; slightly hard, very friable, slightly sticky and moderately plastic; many very fine, fine and medium, few coarse roots; common fine and very fine tubular pores; many faint clay films on faces of peds and lining pores; 10 percent gravel, 10 percent cobbles; moderately acid (pH 6.0); clear smooth boundary.  (18 to 48 cm thick)"
+      },
+      {
+        "name": "Bt2",
+        "top": 36,
+        "bottom": 49,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 3,
+        "texture_class": "clay loam",
+        "cf_class": "gravelly",
+        "pH": 5.5,
+        "pH_class": "strongly acid",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "Bt2--36 to 49 cm; brown (10YR 4/3) gravelly clay loam, dark brown (10YR 3/3) moist; moderate fine and medium subangular blocky structure; hard, friable, moderately sticky and moderately plastic; common very fine, fine and medium, few coarse roots; common fine and very fine tubular pores; many distinct clay films on faces of peds and lining pores; 10 percent gravel, 5 percent cobbles; strongly acid (pH 5.5); clear wavy boundary.  (13 to 43 cm thick)"
+      },
+      {
+        "name": "2Bt",
+        "top": 49,
+        "bottom": 110,
+        "moist_hue": "10YR",
+        "moist_value": 6,
+        "moist_chroma": 6,
+        "texture_class": "clay loam",
+        "cf_class": "gravelly",
+        "pH": 5.5,
+        "pH_class": "strongly acid",
+        "distinctness": "gradual",
+        "topography": "irregular",
+        "narrative": "2Bt--49 to 110 cm; brownish yellow (10YR 6/6) gravelly clay loam, dark yellowish brown (10YR 4/6) moist, with few fine distinct mottles of strong brown (7.5YR 5/6); moderate medium angular blocky structure; hard, friable, slightly sticky and slightly plastic; few fine and very fine roots; common fine and very fine tubular pores; common faint clay films on faces of peds; trace manganese concretions; 20 percent gravel; strongly acid (pH 5.5); gradual irregular boundary.  (0 to 61 cm thick)"
+      },
+      {
+        "name": "2C",
+        "top": 110,
+        "bottom": 155,
+        "moist_hue": "2.5Y",
+        "moist_value": 6,
+        "moist_chroma": 4,
+        "texture_class": "sandy loam",
+        "pH": 5.2,
+        "pH_class": "strongly acid",
+        "narrative": "2C--110 to 155 cm; light yellowish brown (2.5Y 6/4) sandy loam, olive brown (2.5Y 4/4) moist, with few medium prominent mottles of yellow (2.5Y 7/6); massive; very hard, friable, nonsticky and nonplastic; few fine and very fine tubular pores; trace manganese concretions; 5 percent gravel; strongly acid (pH 5.2)."
+      }
+    ]
   ]
 }

--- a/inst/extdata/OSD/S/STONEMAN.json
+++ b/inst/extdata/OSD/S/STONEMAN.json
@@ -153,6 +153,21 @@
         "distinctness": "gradual",
         "topography": "wavy",
         "narrative": "2Bkq2--76 to 109 cm; very pale brown (10YR 8/3) extremely cobbly loam, light yellowish brown (10YR 6/4) moist; weak fine and medium subangular blocky structure; hard, friable, slightly sticky and slightly plastic; common very fine roots; many very fine tubular pores; 25 percent gravel, 45 percent cobbles, and 30 percent stones; calcium carbonate and silica coatings 1 to 5 mm thick on rock fragments; violently effervescent (30 percent calcium carbonate equivalent); moderately alkaline (pH 8.4); gradual wavy boundary"
+      },
+      {
+        "name": "2Bkq3",
+        "top": 109,
+        "dry_hue": "10YR",
+        "dry_value": 7,
+        "dry_chroma": 3,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 4,
+        "texture_class": "loam",
+        "cf_class": "extremely cobbly",
+        "pH": 8.4,
+        "pH_class": "moderately alkaline",
+        "narrative": "2Bkq3--109 to152 cm; very pale brown (10YR 7/3) extremely cobbly loam, yellowish brown (10YR 5/4) moist; weak very fine and fine subangular blocky structure; slightly hard, very friable, slightly sticky and slightly plastic; common very fine irregular pores; 25 percent gravel, 45 percent cobbles, and 30 percent stones; calcium carbonate and silica coatings 2 to 8 mm thick on rock fragments; violently effervescent (21 percent calcium carbonate equivalent); moderately alkaline (pH 8.4)"
       }
     ]
   ]

--- a/inst/extdata/OSD/S/SWEETBRIAR.json
+++ b/inst/extdata/OSD/S/SWEETBRIAR.json
@@ -202,7 +202,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; slightly decomposed needles, leaves, twigs, bark and cone fragments."
       }
     ]

--- a/inst/extdata/OSD/T/TABLEROCK.json
+++ b/inst/extdata/OSD/T/TABLEROCK.json
@@ -142,7 +142,6 @@
       },
       {
         "name": "O",
-        "top": 4,
         "narrative": "O--1.5 inch to 0; partially decomposed leaves, twigs, and"
       },
       {

--- a/inst/extdata/OSD/T/TAMFORD.json
+++ b/inst/extdata/OSD/T/TAMFORD.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 15,
+        "name": "A1",
+        "top": 0,
+        "bottom": 15,
         "dry_hue": "5YR",
         "dry_value": 5,
         "dry_chroma": 2,
@@ -77,8 +78,9 @@
         "narrative": "A1  --  0-6 inches, reddish gray (5YR 5/2) clay loam, dark reddish brown (5YR 3/2) moist; weak fine blocky       structure; very"
       },
       {
-        "name": "30",
-        "top": 137,
+        "name": "AC2",
+        "top": 76,
+        "bottom": 137,
         "moist_hue": "2.5YR",
         "moist_value": 4,
         "moist_chroma": 4,
@@ -86,8 +88,9 @@
         "narrative": "AC2 --  30-54 inches, reddish brown (2.5YR 5?4) clay, reddish brown (2.5YR 4/4) moist? weak coarse blocky structure; extremely hard, extremely firm; few intersecting slickensides; about 5"
       },
       {
-        "name": "54",
-        "top": 183,
+        "name": "C",
+        "top": 137,
+        "bottom": 183,
         "dry_hue": "10R",
         "dry_value": 5,
         "dry_chroma": 6,

--- a/inst/extdata/OSD/T/THIRSTYGULCH.json
+++ b/inst/extdata/OSD/T/THIRSTYGULCH.json
@@ -128,7 +128,6 @@
       },
       {
         "name": "R",
-        "top": 47,
         "narrative": "R--18.5 inches; basalt"
       }
     ]

--- a/inst/extdata/OSD/T/TOMAST.json
+++ b/inst/extdata/OSD/T/TOMAST.json
@@ -65,13 +65,14 @@
   "HORIZONS": [
     [
       {
-        "name": "3/4",
-        "top": 0,
+        "name": "0",
+        "bottom": 0,
         "narrative": "01    --  3/4-0 inches, decaying forest litter."
       },
       {
-        "name": "0",
-        "top": 5,
+        "name": "A1",
+        "top": 0,
+        "bottom": 5,
         "moist_hue": "10YR",
         "moist_value": 3,
         "moist_chroma": 2,
@@ -81,8 +82,9 @@
         "narrative": "A1    --  0-2 inches, very dark grayish brown (10YR 3/2) silt loam; weak medium granular structure; friable; many roots; medium acid; clear wavy boundary.  (2 to 6 inches thick)"
       },
       {
-        "name": "2",
-        "top": 15,
+        "name": "A2",
+        "top": 5,
+        "bottom": 15,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 2,
@@ -90,8 +92,9 @@
         "narrative": "A2    --  2-6 inches, grayish brown (10YR 5/2) silt loam; few fine distinct yellowish brown (10YR 5/6) mottles; weak fine"
       },
       {
-        "name": "6",
-        "top": 56,
+        "name": "B1t",
+        "top": 15,
+        "bottom": 56,
         "moist_hue": "5YR",
         "moist_value": 5,
         "moist_chroma": 6,
@@ -99,8 +102,9 @@
         "narrative": "B1t   --  6-22 inches, yellowish red (5YR 5/6) silty clay"
       },
       {
-        "name": "22",
-        "top": 71,
+        "name": "B21t",
+        "top": 56,
+        "bottom": 71,
         "moist_hue": "7.5YR",
         "moist_value": 5,
         "moist_chroma": 6,
@@ -108,8 +112,9 @@
         "narrative": "B21t  --  22-28 inches, strong brown (7.5YR 5/6) silty clay loam; many medium prominent mottles of gray (10YR 6/1) and a few"
       },
       {
-        "name": "28",
-        "top": 122,
+        "name": "B22tg",
+        "top": 71,
+        "bottom": 122,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 1,
@@ -117,8 +122,9 @@
         "narrative": "B22tg --  28-48 inches, gray (10YR 6/1) silty clay loam; many medium prominent red (2.5YR 4/6) and distinct yellowish brown"
       },
       {
-        "name": "48",
-        "top": 165,
+        "name": "B23tg",
+        "top": 122,
+        "bottom": 165,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 1,
@@ -126,8 +132,9 @@
         "narrative": "B23tg --  48-65 inches, gray (10YR 6/1) silty clay; many"
       },
       {
-        "name": "65",
-        "top": 203,
+        "name": "B3g",
+        "top": 165,
+        "bottom": 203,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 2,
@@ -135,8 +142,9 @@
         "narrative": "B3g   --  65-80 inches, light brownish gray (10YR 6/2) silty clay; common medium distinct mottles of olive brown (2.5Y 4/3) and"
       },
       {
-        "name": "80",
-        "top": 229,
+        "name": "Cg",
+        "top": 203,
+        "bottom": 229,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 2,

--- a/inst/extdata/OSD/T/TRUEFISSURE.json
+++ b/inst/extdata/OSD/T/TRUEFISSURE.json
@@ -143,6 +143,20 @@
         "pH": 6.2,
         "pH_class": "slightly acid",
         "narrative": "2C--42 to 75 inches; pale yellow (2.5Y 7/4) and yellow (2.5Y 8/6) extremely cobbly silt loam, light yellowish brown (10YR 6/4) moist; common distinct yellowish red (5YR 4/6) mottles; massive; slightly hard, friable and brittle, 75 percent cobbles, pebbles and stones; slightly acid (pH 6.2)."
+      },
+      {
+        "name": "2Bw3",
+        "top": 61,
+        "dry_hue": "10YR",
+        "dry_value": 7,
+        "dry_chroma": 4,
+        "texture_class": "silt loam",
+        "cf_class": "extremely cobbly",
+        "pH": 5.6,
+        "pH_class": "moderately acid",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "2Bw3--24 to42 inches; very pale brown (10YR 7/4) extremely cobbly silt loam, yellowish brown (10YR 5/4) massive; soft, very friable; few roots; common medium and fine pores, few coarse pores; walls of some pores stained dark red; 65 percent angular cobbles, pebbles and stones; moderately acid (pH 5.6); clear wavy boundary. (10 to 30 inches thick)"
       }
     ]
   ]

--- a/inst/extdata/OSD/U/UPTMOR.json
+++ b/inst/extdata/OSD/U/UPTMOR.json
@@ -187,7 +187,6 @@
       },
       {
         "name": "Oe",
-        "top": 1,
         "narrative": "Oe--0.5 inch to 0; slightly to moderately decomposed organic material."
       }
     ]

--- a/inst/extdata/OSD/V/VANNOY.json
+++ b/inst/extdata/OSD/V/VANNOY.json
@@ -187,7 +187,6 @@
       },
       {
         "name": "O",
-        "top": 2,
         "narrative": "O--0.75 inch to 0;  partially decomposed litter of needles, leaves and twigs."
       },
       {

--- a/inst/extdata/OSD/W/WELLSDALE.json
+++ b/inst/extdata/OSD/W/WELLSDALE.json
@@ -147,6 +147,22 @@
         "texture_class": "clay loam",
         "pH_class": "very strongly acid",
         "narrative": "BCt---57 to 65 inches; strong brown (7.5YR 5/6), brown (7.5YR 5/4) and light brown (7.5YR 6/4) clay loam, reddish yellow (7.5YR 6/6) and light gray (10YR 7/2) dry; weak medium subangular blocky structure; very hard, firm, moderately sticky and moderately plastic; few very fine and fine roots; many very fine and common fine tubular pores; common prominent clay films on faces of peds, few prominent clay films on surfaces along pores and root channels; few prominent sand coats on faces of peds; common prominent black (10YR 2/1) manganese films; common prominent weak red (2.5YR 5/2) iron depletions; common distinct strong brown (7.5YR 4/6) iron concentrations; very strongly acid (pH 5.0 )"
+      },
+      {
+        "name": "Bt2",
+        "top": 86,
+        "dry_hue": "7.5YR",
+        "dry_value": 6,
+        "dry_chroma": 6,
+        "moist_hue": "7.5YR",
+        "moist_value": 4,
+        "moist_chroma": 4,
+        "texture_class": "clay loam",
+        "pH": 5.2,
+        "pH_class": "strongly acid",
+        "distinctness": "clear",
+        "topography": "wavy",
+        "narrative": "Bt2--34 to57 inches; brown (7.5YR 4/4) clay loam, strong brown (7.5YR 5/6) and reddish yellow (7.5YR 6/6) dry; strong medium angular blocky structure; very hard, firm, moderately sticky and moderately plastic; common very fine and few fine roots; common very fine and few fine tubular pores; common prominent clay films on faces of peds and surfaces along pores and root channels; common prominent sand coats on faces of peds; common prominent black (10YR 2/1) manganese films; common distinct strong brown (7.5YR 4/6) iron concentrations; strongly acid (pH 5.2); clear wavy boundary. (10 to 30 inches thick)"
       }
     ]
   ]

--- a/inst/extdata/OSD/W/WESTON.json
+++ b/inst/extdata/OSD/W/WESTON.json
@@ -65,13 +65,15 @@
   "HORIZONS": [
     [
       {
-        "name": "1",
-        "top": 0,
+        "name": "01",
+        "top": 3,
+        "bottom": 0,
         "narrative": "01   --  1-0 inches, pine needles, leaves, and twigs."
       },
       {
-        "name": "0",
-        "top": 10,
+        "name": "A1",
+        "top": 0,
+        "bottom": 10,
         "moist_hue": "10YR",
         "moist_value": 5,
         "moist_chroma": 2,
@@ -79,16 +81,18 @@
         "narrative": "A1   --  0-4 inches, grayish brown (10YR 5/2) fine sandy"
       },
       {
-        "name": "4",
-        "top": 23,
+        "name": "A2",
+        "top": 10,
+        "bottom": 23,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 2,
         "narrative": "A2   --  4-9 inches, light brownish gray (10YR 6/2) fine"
       },
       {
-        "name": "9",
-        "top": 61,
+        "name": "B2tg",
+        "top": 23,
+        "bottom": 61,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 1,
@@ -96,16 +100,18 @@
         "narrative": "B2tg --  9-24 inches, gray (10YR 6/1) sandy loam, common fine"
       },
       {
-        "name": "24",
-        "top": 112,
+        "name": "B3g",
+        "top": 61,
+        "bottom": 112,
         "moist_hue": "10YR",
         "moist_value": 7,
         "moist_chroma": 1,
         "narrative": "B3g  --  24-44 inches, mottled light gray (10YR 7/1),"
       },
       {
-        "name": "44",
-        "top": 137,
+        "name": "Cg",
+        "top": 112,
+        "bottom": 137,
         "moist_hue": "10YR",
         "moist_value": 6,
         "moist_chroma": 1,

--- a/inst/extdata/OSD/W/WHAKANA.json
+++ b/inst/extdata/OSD/W/WHAKANA.json
@@ -67,8 +67,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 23,
+        "name": "Ap",
+        "top": 0,
+        "bottom": 23,
         "moist_hue": "7.5YR",
         "moist_value": 4,
         "moist_chroma": 4,
@@ -78,8 +79,9 @@
         "narrative": "Ap--0-9 inches, brown (7.5YR 4/4) loam; moderate fine granular structure; slightly hard, very friable; many fine roots; few wormcasts; medium acid; clear smooth boundary.  (5 to 12 inches thick)"
       },
       {
-        "name": "9",
-        "top": 36,
+        "name": "E",
+        "top": 23,
+        "bottom": 36,
         "moist_hue": "7.5YR",
         "moist_value": 5,
         "moist_chroma": 4,
@@ -87,8 +89,9 @@
         "narrative": "E--9-14 inches, brown (7.5YR 5/4) loam; weak fine subangular"
       },
       {
-        "name": "14",
-        "top": 61,
+        "name": "Bt1",
+        "top": 36,
+        "bottom": 61,
         "moist_hue": "5YR",
         "moist_value": 4,
         "moist_chroma": 6,
@@ -99,8 +102,9 @@
         "narrative": "Bt1--14-24 inches, yellowish red (5YR 4/6) clay loam; few coarse faint mottles of red (2.5YR 4/6); moderate fine subangular blocky structure; hard, friable; common fine roots; few fine pores; patchy clay films on surfaces of peds; few medium strong brown pockets of loamy sand (A2); slightly acid; diffuse smooth boundary.  (3 to 12 inches thick)"
       },
       {
-        "name": "24",
-        "top": 86,
+        "name": "Bt2",
+        "top": 61,
+        "bottom": 86,
         "moist_hue": "5YR",
         "moist_value": 5,
         "moist_chroma": 6,
@@ -111,8 +115,9 @@
         "narrative": "Bt2--24-34 inches, yellowish red (5YR 5/6) clay loam; about 20 percent coarse distinct mottles with interiors of red (2.5YR 4/6) and exteriors of dark reddish brown (2.5YR 3/4); weak coarse prismatic structure parting to moderate fine subangular blocky structure; very hard, friable; common fine roots; few fine voids; clay films on the surface of some peds; few silt coatings on surface of other peds; few black nodules; about 15 percent of distinct light brown vertical streaks about 2 to 5 mm. wide of loamy sand on face of prisms; strongly acid; clear wavy boundary. (8 to 24 inches thick)"
       },
       {
-        "name": "34",
-        "top": 117,
+        "name": "Bt3",
+        "top": 86,
+        "bottom": 117,
         "moist_hue": "2.5YR",
         "moist_value": 3,
         "moist_chroma": 6,
@@ -120,8 +125,9 @@
         "narrative": "Bt3--34-46 inches, dark red (2.5YR 3/6) loam; weak coarse"
       },
       {
-        "name": "46",
-        "top": 160,
+        "name": "Bt/E",
+        "top": 117,
+        "bottom": 160,
         "moist_hue": "2.5YR",
         "moist_value": 4,
         "moist_chroma": 6,
@@ -132,8 +138,9 @@
         "narrative": "Bt/E--46-63 inches, red (2.5YR 4/6) loam; weak coarse prismatic structure parting to weak medium subangular blocky structure; very hard, slightly brittle in about 10 to 15 percent of the matrix; few fine roots in gray zones; red (2.5YR 4/6) ped interiors are sandy clay loam with dark red (2.5YR 3/6) clay coatings; faces of prisms are coated with gray (10YR 6/1) sandy clay about 1 mm. thick; about 10 to 14 percent white (10YR 8/1) streaks and tongues of loamy sand; tongues are 2 to 5 cm. wide and taper to 5 to 10 mm.; common vesicules lined with clay; very strongly acid; diffuse irregular boundary.  (0 to 20 inches thick)"
       },
       {
-        "name": "63",
-        "top": 203,
+        "name": "Bt/E3",
+        "top": 160,
+        "bottom": 203,
         "moist_hue": "5YR",
         "moist_value": 4,
         "moist_chroma": 6,

--- a/inst/extdata/OSD/W/WILHOIT.json
+++ b/inst/extdata/OSD/W/WILHOIT.json
@@ -149,6 +149,11 @@
         "narrative": "BC--43 to 52 inches; brown (7.5YR 4/4) gravelly loam, yellowish brown (10YR 5/4) dry; weak medium subangular blocky structure; hard, firm, slightly sticky and slightly plastic; few fine and very fine roots; many very fine tubular pores; 25 percent gravel; strongly acid (pH 5.2).  (5 to 10 inches thick)"
       },
       {
+        "name": "Oi",
+        "top": 0,
+        "narrative": "Oi--0 to1 inch; slightly decomposed litter of needles, leaves, and twigs."
+      },
+      {
         "name": "Cr",
         "top": 132,
         "narrative": "Cr--52 inches; soft weathered tuff."

--- a/inst/extdata/OSD/W/WILLACY.json
+++ b/inst/extdata/OSD/W/WILLACY.json
@@ -67,6 +67,16 @@
   "HORIZONS": [
     [
       {
+        "name": "Ap",
+        "top": 0,
+        "bottom": 18,
+        "dry_hue": "10YR",
+        "dry_value": 4,
+        "dry_chroma": 2,
+        "texture_class": "fine sand",
+        "narrative": "Ap-=0 to 7 inches; dark grayish brown (10YR 4/2) fine sandy"
+      },
+      {
         "name": "A",
         "top": 18,
         "bottom": 36,

--- a/inst/extdata/OSD/W/WINGINA.json
+++ b/inst/extdata/OSD/W/WINGINA.json
@@ -65,6 +65,45 @@
     ]
   ],
   "HORIZONS": [
-    {}
+    [
+      {
+        "name": "Ap",
+        "top": 0,
+        "bottom": 36,
+        "dry_hue": "10YR",
+        "dry_value": 5,
+        "dry_chroma": 3,
+        "moist_hue": "10YR",
+        "moist_value": 3,
+        "moist_chroma": 2,
+        "texture_class": "loam",
+        "pH_class": "neutral",
+        "distinctness": "abrupt",
+        "topography": "smooth",
+        "narrative": "Ap=0 to 14 inches; very dark grayish brown (10YR 3/2) broken, dark brown (10YR 3/3) crushed, loam; brown (10YR 5/3) dry; moderate medium granular structure; friable, slightly sticky, slightly plastic; few fine and medium roots; common fine flakes of mica; neutral; abrupt smooth boundary. (Ap and A horizons are 10 to 24 inches thick)"
+      },
+      {
+        "name": "Bw1",
+        "top": 36,
+        "bottom": 102,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 3,
+        "texture_class": "loam",
+        "pH_class": "neutral",
+        "narrative": "Bw1=14 to 40 inches; brown (10YR 4/3) loam; weak coarse subangular blocky structure; friable, slightly sticky, slightly plastic; few fine and medium roots; common fine flakes of mica; neutral."
+      },
+      {
+        "name": "Bw2",
+        "top": 102,
+        "bottom": 183,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 3,
+        "texture_class": "loam",
+        "pH_class": "neutral",
+        "narrative": "Bw2=40 to 72 inches; brown (10YR 4/3) loam; weak coarse subangular blocky structure; friable, slightly sticky, slightly plastic; common fine flakes of mica; neutral. (Combined thickness of the Bw horizon is 20 to 60 inches or more)"
+      }
+    ]
   ]
 }

--- a/inst/extdata/OSD/W/WITTEN.json
+++ b/inst/extdata/OSD/W/WITTEN.json
@@ -131,6 +131,22 @@
         "narrative": "Bt--36 to 66 centimeters (14 to 26 inches); dark grayish brown (10YR 4/2) clay, very dark grayish brown (10YR 3/2) moist; strong fine and medium blocky structure; very hard, very firm, sticky and plastic; strong effervescence; slightly alkaline; clear irregular boundary. [Combined Bt horizon depth is 30 to 51 centimeters (12 to 20 inches) thick.]"
       },
       {
+        "name": "BCss",
+        "top": 66,
+        "bottom": 104,
+        "dry_hue": "2.5Y",
+        "dry_value": 5,
+        "dry_chroma": 2,
+        "moist_hue": "10YR",
+        "moist_value": 4,
+        "moist_chroma": 2,
+        "texture_class": "clay",
+        "pH_class": "moderately alkaline",
+        "distinctness": "gradual",
+        "topography": "wavy",
+        "narrative": "BCss--66 104 centimeters (26 to 41 inches); grayish brown (2.5Y 5/2) clay, dark grayish brown (10YR 4/2) moist; moderate medium blocky structure; extremely hard, extremely firm, very sticky and very plastic; few tongues, about .5 to 3 centimeters (1/4 to 1 inch) wide, of dark grayish brown (10YR 4/2); many pressure faces and common slickensides; strong effervescence; moderately alkaline; gradual wavy boundary.  [0 to 46 centimeters (0 to 18 inches thick).]"
+      },
+      {
         "name": "Cy",
         "top": 104,
         "bottom": 152,

--- a/inst/extdata/OSD/W/WOLCO.json
+++ b/inst/extdata/OSD/W/WOLCO.json
@@ -65,8 +65,9 @@
   "HORIZONS": [
     [
       {
-        "name": "0",
-        "top": 36,
+        "name": "A1",
+        "top": 0,
+        "bottom": 36,
         "dry_hue": "10YR",
         "dry_value": 4,
         "dry_chroma": 1,
@@ -74,29 +75,33 @@
         "narrative": "A1   --  0-14 inches, dark gray (10YR 4/1) silty clay loam,"
       },
       {
-        "name": "14",
-        "top": 53,
+        "name": "B1",
+        "top": 36,
+        "bottom": 53,
         "dry_hue": "10YR",
         "dry_value": 3,
         "dry_chroma": 2,
         "narrative": "B1   --  14-21 inches, very dark grayish brown (10YR 3/2)"
       },
       {
-        "name": "21",
-        "top": 91,
+        "name": "B21t",
+        "top": 53,
+        "bottom": 91,
         "dry_hue": "7.5YR",
         "dry_value": 5,
         "dry_chroma": 2,
         "narrative": "B21t --  21-36 inches, coarsely mottled brown (7.5YR 5/2),"
       },
       {
-        "name": "36",
-        "top": 140,
+        "name": "B22t",
+        "top": 91,
+        "bottom": 140,
         "narrative": "B22t --  36-55 inches, coarsely mottled yellowish red (5YR"
       },
       {
-        "name": "55",
-        "top": 152,
+        "name": "R",
+        "top": 140,
+        "bottom": 152,
         "narrative": "R    --  55-60 inches, hard limestone bedrock; coarsely"
       }
     ]

--- a/inst/extdata/OSD/W/WOLFPEAK.json
+++ b/inst/extdata/OSD/W/WOLFPEAK.json
@@ -134,7 +134,6 @@
       },
       {
         "name": "Oi",
-        "top": 1,
         "narrative": "Oi--0.5 inch to 0; partially decomposed needles, leaves, and twigs."
       }
     ]

--- a/inst/extdata/OSD/Y/YOGAVILLE.json
+++ b/inst/extdata/OSD/Y/YOGAVILLE.json
@@ -65,6 +65,57 @@
     ]
   ],
   "HORIZONS": [
-    {}
+    [
+      {
+        "name": "Ap",
+        "top": 0,
+        "bottom": 36,
+        "moist_hue": "10YR",
+        "moist_value": 3,
+        "moist_chroma": 2,
+        "texture_class": "loam",
+        "pH_class": "neutral",
+        "distinctness": "abrupt",
+        "topography": "smooth",
+        "narrative": "Ap=0 to 14 inches; very dark grayish brown (10YR 3/2) broken, dark brown (10YR 3/3) crushed, loam; brown (10YR 5/3 dry; moderate medium granular structure; friable, slightly sticky, slightly plastic; few fine and medium roots; few fine flakes of mica; neutral; abrupt smooth boundary.  (Ap and A horizons are 10 to 24 inches thick)"
+      },
+      {
+        "name": "Bg1",
+        "top": 36,
+        "bottom": 81,
+        "moist_hue": "10YR",
+        "moist_value": 6,
+        "moist_chroma": 1,
+        "texture_class": "clay loam",
+        "pH_class": "neutral",
+        "distinctness": "clear",
+        "topography": "smooth",
+        "narrative": "Bg1=14 to 32 inches; light gray (10YR 6/1) clay loam; many medium distinct yellowish brown (10YR 5/4) mottles; weak coarse subangular blocky structure; friable, slightly sticky, slightly plastic; few fine roots; few fine flakes of mica; neutral; clear smooth boundary."
+      },
+      {
+        "name": "Bg2",
+        "top": 81,
+        "bottom": 140,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 1,
+        "texture_class": "silt loam",
+        "pH_class": "slightly acid",
+        "distinctness": "clear",
+        "topography": "smooth",
+        "narrative": "Bg2=32 to 55 inches; mottled gray (10YR 5/1) and yellowish brown (10YR 5/6) silt loam; weak coarse subangular blocky structure; friable, slightly sticky, slightly plastic; few fine flakes of mica; slightly acid; clear smooth boundary."
+      },
+      {
+        "name": "Bg3",
+        "top": 140,
+        "bottom": 183,
+        "moist_hue": "10YR",
+        "moist_value": 5,
+        "moist_chroma": 1,
+        "texture_class": "loam",
+        "pH_class": "slightly acid",
+        "narrative": "Bg3=55 to 72 inches; gray (10YR 5/1) loam; common medium prominent yellowish brown (10YR 5/6) mottles; weak coarse subangular blocky structure; friable, slightly sticky, slightly plastic; few fine flakes of mica; 5 percent gravel; slightly acid.  (Combined thickness of the Bg horizons is 20 to 60 inches or more)"
+      }
+    ]
   ]
 }

--- a/inst/extdata/OSD/Z/ZING.json
+++ b/inst/extdata/OSD/Z/ZING.json
@@ -168,7 +168,6 @@
       },
       {
         "name": "Oi",
-        "top": 4,
         "narrative": "Oi--1.5 inch to 0; loose, undecomposed and partially decomposed needles, twigs, leaves and moss."
       }
     ]


### PR DESCRIPTION
Doing some QC on the parsed horizon-level output from "Typical Pedon" sections

- Some more unusual cases added to header parsing
- Handling of different separator types between horizon designation and depths, and between depths and making sure the missing-bottom-depth code triggers/names results correctly

Working with @dylanbeaudette to patch up some problematic parsing and get the list of OSDs with irreconcilable errors (e.g. Sabana, Marcy, Ariel) related to the TYPICAL PEDON section. 
