### PR TITLE
[OSD] Improve drainage class parsing

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -25,7 +25,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Imports: curl, xml2, jsonlite, rvest, stringi, tibble, dplyr, pdftools, data.tab
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Suggests: 
     knitr,
     rmarkdown,

--- a/R/create_OSD.R
+++ b/R/create_OSD.R
@@ -3,10 +3,11 @@
 #' Create OSD Dataset
 #'
 #' @param ... not used
+#' @param download _logical_. Download OSD Snapshot from OSDRegistry? Default: `TRUE`
 #'
 #' @return TRUE if successful
 #' @export
-create_OSD <- function(...) {
+create_OSD <- function(..., download = TRUE) {
 
   output_dir <- "inst/extdata/OSD"
   logfile <- file.path(output_dir, "OSD.log")
@@ -15,9 +16,11 @@ create_OSD <- function(...) {
 
   attempt <- try({
 
-        logmsg(logfile, "Downloading snapshot...")
-        # Download OSDRegistry snapshot
-        download_OSD(url = 'https://github.com/ncss-tech/OSDRegistry/releases/download/main/OSD-data-snapshot.zip')
+        if (download) {
+          logmsg(logfile, "Downloading snapshot...")
+          # Download OSDRegistry snapshot
+          download_OSD(url = 'https://github.com/ncss-tech/OSDRegistry/releases/download/main/OSD-data-snapshot.zip')
+        }
 
         # Do JSON parsing of sections
         res <- osd_to_json(logfile = logfile,

--- a/inst/extdata/OSD/A/AABERG.json
+++ b/inst/extdata/OSD/A/AABERG.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ABAC.json
+++ b/inst/extdata/OSD/A/ABAC.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ABAJO.json
+++ b/inst/extdata/OSD/A/ABAJO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ABALAN.json
+++ b/inst/extdata/OSD/A/ABALAN.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ABERONE.json
+++ b/inst/extdata/OSD/A/ABERONE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively or well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ABGESE.json
+++ b/inst/extdata/OSD/A/ABGESE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ABIQUA.json
+++ b/inst/extdata/OSD/A/ABIQUA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ABREU.json
+++ b/inst/extdata/OSD/A/ABREU.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ABSHER.json
+++ b/inst/extdata/OSD/A/ABSHER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ACADEMY.json
+++ b/inst/extdata/OSD/A/ACADEMY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/A/ACO.json
+++ b/inst/extdata/OSD/A/ACO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ADAMS.json
+++ b/inst/extdata/OSD/A/ADAMS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat excessively",
-        "drainage_overview": "excessively and somewhat excessively"
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ADGER.json
+++ b/inst/extdata/OSD/A/ADGER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ADILIS.json
+++ b/inst/extdata/OSD/A/ADILIS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ADJIDAUMO.json
+++ b/inst/extdata/OSD/A/ADJIDAUMO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ADOLPH.json
+++ b/inst/extdata/OSD/A/ADOLPH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AGER.json
+++ b/inst/extdata/OSD/A/AGER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/AGUA_DULCE.json
+++ b/inst/extdata/OSD/A/AGUA_DULCE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/A/AGUEDA.json
+++ b/inst/extdata/OSD/A/AGUEDA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/A/AHL.json
+++ b/inst/extdata/OSD/A/AHL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/AILEY.json
+++ b/inst/extdata/OSD/A/AILEY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AINAHOU.json
+++ b/inst/extdata/OSD/A/AINAHOU.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AKAN.json
+++ b/inst/extdata/OSD/A/AKAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALAMOSA.json
+++ b/inst/extdata/OSD/A/ALAMOSA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
-        "drainage_overview": "poorly to somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALANTHUS.json
+++ b/inst/extdata/OSD/A/ALANTHUS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALBATON.json
+++ b/inst/extdata/OSD/A/ALBATON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALBINAS.json
+++ b/inst/extdata/OSD/A/ALBINAS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ALBION.json
+++ b/inst/extdata/OSD/A/ALBION.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "somewhat excessively, well"
       }
     ]

--- a/inst/extdata/OSD/A/ALBION.json
+++ b/inst/extdata/OSD/A/ALBION.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALBRIGHTS.json
+++ b/inst/extdata/OSD/A/ALBRIGHTS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALCESTER.json
+++ b/inst/extdata/OSD/A/ALCESTER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALDA.json
+++ b/inst/extdata/OSD/A/ALDA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALDERMAND.json
+++ b/inst/extdata/OSD/A/ALDERMAND.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALET.json
+++ b/inst/extdata/OSD/A/ALET.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ALGERITA.json
+++ b/inst/extdata/OSD/A/ALGERITA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ALICE.json
+++ b/inst/extdata/OSD/A/ALICE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ALLANTON.json
+++ b/inst/extdata/OSD/A/ALLANTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALLENTINE.json
+++ b/inst/extdata/OSD/A/ALLENTINE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALLIANCE.json
+++ b/inst/extdata/OSD/A/ALLIANCE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ALLISON.json
+++ b/inst/extdata/OSD/A/ALLISON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALMERIA.json
+++ b/inst/extdata/OSD/A/ALMERIA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "very poorly",
-        "drainage_overview": "poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALMERIA.json
+++ b/inst/extdata/OSD/A/ALMERIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly, very poorly"
       }
     ]

--- a/inst/extdata/OSD/A/ALMONT.json
+++ b/inst/extdata/OSD/A/ALMONT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
-        "drainage_overview": "poorly to somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALO.json
+++ b/inst/extdata/OSD/A/ALO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ALOVAR.json
+++ b/inst/extdata/OSD/A/ALOVAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ALPON.json
+++ b/inst/extdata/OSD/A/ALPON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ALTAZANO.json
+++ b/inst/extdata/OSD/A/ALTAZANO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALTICREST.json
+++ b/inst/extdata/OSD/A/ALTICREST.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ALTMAR.json
+++ b/inst/extdata/OSD/A/ALTMAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALTOGA.json
+++ b/inst/extdata/OSD/A/ALTOGA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ALTON.json
+++ b/inst/extdata/OSD/A/ALTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ALTURAS.json
+++ b/inst/extdata/OSD/A/ALTURAS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/A/ALVODEST.json
+++ b/inst/extdata/OSD/A/ALVODEST.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to moderately well",
-        "drainage_overview": "somewhat poorly to moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AMARADA.json
+++ b/inst/extdata/OSD/A/AMARADA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AMASA.json
+++ b/inst/extdata/OSD/A/AMASA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AMES.json
+++ b/inst/extdata/OSD/A/AMES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AMTOFT.json
+++ b/inst/extdata/OSD/A/AMTOFT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AMWELL.json
+++ b/inst/extdata/OSD/A/AMWELL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ANAHEIM.json
+++ b/inst/extdata/OSD/A/ANAHEIM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ANAN.json
+++ b/inst/extdata/OSD/A/ANAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ANCHO.json
+++ b/inst/extdata/OSD/A/ANCHO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/A/ANDERS.json
+++ b/inst/extdata/OSD/A/ANDERS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ANGELICA.json
+++ b/inst/extdata/OSD/A/ANGELICA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ANGUILLA.json
+++ b/inst/extdata/OSD/A/ANGUILLA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ANKONA.json
+++ b/inst/extdata/OSD/A/ANKONA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ANNRIVER.json
+++ b/inst/extdata/OSD/A/ANNRIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ANTERO.json
+++ b/inst/extdata/OSD/A/ANTERO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
-        "drainage_overview": "poorly to somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ANTILON.json
+++ b/inst/extdata/OSD/A/ANTILON.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ANTIOCH.json
+++ b/inst/extdata/OSD/A/ANTIOCH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/A/ANTY.json
+++ b/inst/extdata/OSD/A/ANTY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ANT_FLAT.json
+++ b/inst/extdata/OSD/A/ANT_FLAT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ANWAY.json
+++ b/inst/extdata/OSD/A/ANWAY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ANZA.json
+++ b/inst/extdata/OSD/A/ANZA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/A/AOWA.json
+++ b/inst/extdata/OSD/A/AOWA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/APISHAPA.json
+++ b/inst/extdata/OSD/A/APISHAPA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AQUAPAUG.json
+++ b/inst/extdata/OSD/A/AQUAPAUG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ARAPIEN.json
+++ b/inst/extdata/OSD/A/ARAPIEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ARBOLADO.json
+++ b/inst/extdata/OSD/A/ARBOLADO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ARCHES.json
+++ b/inst/extdata/OSD/A/ARCHES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ARCTANDER.json
+++ b/inst/extdata/OSD/A/ARCTANDER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ARD.json
+++ b/inst/extdata/OSD/A/ARD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ARDTOO.json
+++ b/inst/extdata/OSD/A/ARDTOO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ARGENT.json
+++ b/inst/extdata/OSD/A/ARGENT.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ARIS.json
+++ b/inst/extdata/OSD/A/ARIS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/A/ARLINGTON.json
+++ b/inst/extdata/OSD/A/ARLINGTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/A/ARLO.json
+++ b/inst/extdata/OSD/A/ARLO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ARNEGARD.json
+++ b/inst/extdata/OSD/A/ARNEGARD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ARNOT.json
+++ b/inst/extdata/OSD/A/ARNOT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively to moderately well"
+        "drainage": "somewhat excessively, well, moderately well",
+        "drainage_overview": "somewhat excessively, well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AROSA.json
+++ b/inst/extdata/OSD/A/AROSA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ARP.json
+++ b/inst/extdata/OSD/A/ARP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ARROYO_SECO.json
+++ b/inst/extdata/OSD/A/ARROYO_SECO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/A/ARTESIAN.json
+++ b/inst/extdata/OSD/A/ARTESIAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ARVESON.json
+++ b/inst/extdata/OSD/A/ARVESON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ASHDOWN.json
+++ b/inst/extdata/OSD/A/ASHDOWN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ASHLAR.json
+++ b/inst/extdata/OSD/A/ASHLAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "excessively"
       }
     ]

--- a/inst/extdata/OSD/A/ASHUE.json
+++ b/inst/extdata/OSD/A/ASHUE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ASHWORTH.json
+++ b/inst/extdata/OSD/A/ASHWORTH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ATASCOSA.json
+++ b/inst/extdata/OSD/A/ATASCOSA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/ATHERTON.json
+++ b/inst/extdata/OSD/A/ATHERTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/ATOKA.json
+++ b/inst/extdata/OSD/A/ATOKA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/AUGSBURG.json
+++ b/inst/extdata/OSD/A/AUGSBURG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AUSMUS.json
+++ b/inst/extdata/OSD/A/AUSMUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AUSTIN.json
+++ b/inst/extdata/OSD/A/AUSTIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/A/AUSTWELL.json
+++ b/inst/extdata/OSD/A/AUSTWELL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/A/AUTOMBA.json
+++ b/inst/extdata/OSD/A/AUTOMBA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/A/AXTELL.json
+++ b/inst/extdata/OSD/A/AXTELL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/A/AYERSVILLE.json
+++ b/inst/extdata/OSD/A/AYERSVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BACH.json
+++ b/inst/extdata/OSD/B/BACH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BACID.json
+++ b/inst/extdata/OSD/B/BACID.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BADGERPASS.json
+++ b/inst/extdata/OSD/B/BADGERPASS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
+        "drainage": "excessively, somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/B/BADRIVER.json
+++ b/inst/extdata/OSD/B/BADRIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BADUS.json
+++ b/inst/extdata/OSD/B/BADUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
-        "drainage_overview": "somewhat poorly or poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BAFFIN.json
+++ b/inst/extdata/OSD/B/BAFFIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BAGARD.json
+++ b/inst/extdata/OSD/B/BAGARD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BAGAUL.json
+++ b/inst/extdata/OSD/B/BAGAUL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BAGVAL.json
+++ b/inst/extdata/OSD/B/BAGVAL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BAILEY.json
+++ b/inst/extdata/OSD/B/BAILEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BALDY.json
+++ b/inst/extdata/OSD/B/BALDY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BALKAN.json
+++ b/inst/extdata/OSD/B/BALKAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BALKYHORSE.json
+++ b/inst/extdata/OSD/B/BALKYHORSE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BALLARD.json
+++ b/inst/extdata/OSD/B/BALLARD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BALLINGER.json
+++ b/inst/extdata/OSD/B/BALLINGER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BALLONA.json
+++ b/inst/extdata/OSD/B/BALLONA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BALMAN.json
+++ b/inst/extdata/OSD/B/BALMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BALON.json
+++ b/inst/extdata/OSD/B/BALON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BALTIC.json
+++ b/inst/extdata/OSD/B/BALTIC.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BAMBER.json
+++ b/inst/extdata/OSD/B/BAMBER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BANCAS.json
+++ b/inst/extdata/OSD/B/BANCAS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BANCROFT.json
+++ b/inst/extdata/OSD/B/BANCROFT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BANGSTON.json
+++ b/inst/extdata/OSD/B/BANGSTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BANISTER.json
+++ b/inst/extdata/OSD/B/BANISTER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BANKARD.json
+++ b/inst/extdata/OSD/B/BANKARD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively to somewhat excessively",
-        "drainage_overview": "excessively to somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BANKS.json
+++ b/inst/extdata/OSD/B/BANKS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively or somewhat excessively",
-        "drainage_overview": "excessively or somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BARELA.json
+++ b/inst/extdata/OSD/B/BARELA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BARFIELD.json
+++ b/inst/extdata/OSD/B/BARFIELD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BARFUSS.json
+++ b/inst/extdata/OSD/B/BARFUSS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BARISHMAN.json
+++ b/inst/extdata/OSD/B/BARISHMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BARNEY.json
+++ b/inst/extdata/OSD/B/BARNEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BARTLESVILLE.json
+++ b/inst/extdata/OSD/B/BARTLESVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/B/BASCOM.json
+++ b/inst/extdata/OSD/B/BASCOM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BASFORD.json
+++ b/inst/extdata/OSD/B/BASFORD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BASTROPBAY.json
+++ b/inst/extdata/OSD/B/BASTROPBAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BASTSIL.json
+++ b/inst/extdata/OSD/B/BASTSIL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BATHEL.json
+++ b/inst/extdata/OSD/B/BATHEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/B/BATTERSON.json
+++ b/inst/extdata/OSD/B/BATTERSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "excessively"
       }
     ]

--- a/inst/extdata/OSD/B/BATTLEMENT.json
+++ b/inst/extdata/OSD/B/BATTLEMENT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BATTLE_CREEK.json
+++ b/inst/extdata/OSD/B/BATTLE_CREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BATZA.json
+++ b/inst/extdata/OSD/B/BATZA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BAVARIA.json
+++ b/inst/extdata/OSD/B/BAVARIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/B/BAYAMON.json
+++ b/inst/extdata/OSD/B/BAYAMON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BAYSHORE.json
+++ b/inst/extdata/OSD/B/BAYSHORE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
-        "drainage_overview": "somewhat poorly and poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BEAD.json
+++ b/inst/extdata/OSD/B/BEAD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BEARBEACH.json
+++ b/inst/extdata/OSD/B/BEARBEACH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/B/BEAR_BASIN.json
+++ b/inst/extdata/OSD/B/BEAR_BASIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BEAR_CREEK.json
+++ b/inst/extdata/OSD/B/BEAR_CREEK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BEAR_LAKE.json
+++ b/inst/extdata/OSD/B/BEAR_LAKE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BEAUCOUP.json
+++ b/inst/extdata/OSD/B/BEAUCOUP.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BEAUMAIN.json
+++ b/inst/extdata/OSD/B/BEAUMAIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BEAVERTAIL.json
+++ b/inst/extdata/OSD/B/BEAVERTAIL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BECKTON.json
+++ b/inst/extdata/OSD/B/BECKTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BEETREE.json
+++ b/inst/extdata/OSD/B/BEETREE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BELFIELD.json
+++ b/inst/extdata/OSD/B/BELFIELD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BELLEVILLE.json
+++ b/inst/extdata/OSD/B/BELLEVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BELLOTA.json
+++ b/inst/extdata/OSD/B/BELLOTA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BELUGA.json
+++ b/inst/extdata/OSD/B/BELUGA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BELVUE.json
+++ b/inst/extdata/OSD/B/BELVUE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BELVUE.json
+++ b/inst/extdata/OSD/B/BELVUE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BENCHLAKE.json
+++ b/inst/extdata/OSD/B/BENCHLAKE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively or excessively",
-        "drainage_overview": "somewhat excessively or excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BENCLARE.json
+++ b/inst/extdata/OSD/B/BENCLARE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BENDEMEERE.json
+++ b/inst/extdata/OSD/B/BENDEMEERE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BENFIELD.json
+++ b/inst/extdata/OSD/B/BENFIELD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BENSON.json
+++ b/inst/extdata/OSD/B/BENSON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively and excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BENTEEN.json
+++ b/inst/extdata/OSD/B/BENTEEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BENTFORT.json
+++ b/inst/extdata/OSD/B/BENTFORT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
-        "drainage_overview": "moderately well to well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BEOTIA.json
+++ b/inst/extdata/OSD/B/BEOTIA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BERGKELLER.json
+++ b/inst/extdata/OSD/B/BERGKELLER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BERLIN.json
+++ b/inst/extdata/OSD/B/BERLIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BERNOW.json
+++ b/inst/extdata/OSD/B/BERNOW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BERRAY.json
+++ b/inst/extdata/OSD/B/BERRAY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BERTRAM.json
+++ b/inst/extdata/OSD/B/BERTRAM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BESTPITCH.json
+++ b/inst/extdata/OSD/B/BESTPITCH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "very poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BETONNIE.json
+++ b/inst/extdata/OSD/B/BETONNIE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BEW.json
+++ b/inst/extdata/OSD/B/BEW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BICKMORE.json
+++ b/inst/extdata/OSD/B/BICKMORE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BIEBER.json
+++ b/inst/extdata/OSD/B/BIEBER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIGAPPLE.json
+++ b/inst/extdata/OSD/B/BIGAPPLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIGBEND.json
+++ b/inst/extdata/OSD/B/BIGBEND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIGETTY.json
+++ b/inst/extdata/OSD/B/BIGETTY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BIGHEART.json
+++ b/inst/extdata/OSD/B/BIGHEART.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIGMOW.json
+++ b/inst/extdata/OSD/B/BIGMOW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BIGRANT.json
+++ b/inst/extdata/OSD/B/BIGRANT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIGTREE.json
+++ b/inst/extdata/OSD/B/BIGTREE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIGWALL.json
+++ b/inst/extdata/OSD/B/BIGWALL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIGWIN.json
+++ b/inst/extdata/OSD/B/BIGWIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
-        "drainage_overview": "somewhat poorly or poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIG_BLUE.json
+++ b/inst/extdata/OSD/B/BIG_BLUE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or somewhat poorly",
-        "drainage_overview": "poorly or somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIG_CYPRESS.json
+++ b/inst/extdata/OSD/B/BIG_CYPRESS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIJOU.json
+++ b/inst/extdata/OSD/B/BIJOU.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BILLETT.json
+++ b/inst/extdata/OSD/B/BILLETT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BILLINGS.json
+++ b/inst/extdata/OSD/B/BILLINGS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BILLINGTON.json
+++ b/inst/extdata/OSD/B/BILLINGTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BINFORD.json
+++ b/inst/extdata/OSD/B/BINFORD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIRDS.json
+++ b/inst/extdata/OSD/B/BIRDS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BIRDSBORO.json
+++ b/inst/extdata/OSD/B/BIRDSBORO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BISCAY.json
+++ b/inst/extdata/OSD/B/BISCAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BISCAYNE.json
+++ b/inst/extdata/OSD/B/BISCAYNE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BITTON.json
+++ b/inst/extdata/OSD/B/BITTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BLACKBEAR.json
+++ b/inst/extdata/OSD/B/BLACKBEAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BLACKBURN.json
+++ b/inst/extdata/OSD/B/BLACKBURN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BLACKETT.json
+++ b/inst/extdata/OSD/B/BLACKETT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BLACKLEED.json
+++ b/inst/extdata/OSD/B/BLACKLEED.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BLACKLOCK.json
+++ b/inst/extdata/OSD/B/BLACKLOCK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/B/BLACKLOUP.json
+++ b/inst/extdata/OSD/B/BLACKLOUP.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BLACKROCK.json
+++ b/inst/extdata/OSD/B/BLACKROCK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BLACK_CANYON.json
+++ b/inst/extdata/OSD/B/BLACK_CANYON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BLACK_RIDGE.json
+++ b/inst/extdata/OSD/B/BLACK_RIDGE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BLAGO.json
+++ b/inst/extdata/OSD/B/BLAGO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BLAIRTON.json
+++ b/inst/extdata/OSD/B/BLAIRTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to moderately well",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BLAMER.json
+++ b/inst/extdata/OSD/B/BLAMER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BLANCA.json
+++ b/inst/extdata/OSD/B/BLANCA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BLANCHE.json
+++ b/inst/extdata/OSD/B/BLANCHE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BLANDBURG.json
+++ b/inst/extdata/OSD/B/BLANDBURG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively and excessively",
-        "drainage_overview": "somewhat excessively and excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BLANFORT.json
+++ b/inst/extdata/OSD/B/BLANFORT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BLANTON.json
+++ b/inst/extdata/OSD/B/BLANTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "somewhat excessively, well, moderately well",
+        "drainage_overview": "somewhat excessively, well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BLOOM.json
+++ b/inst/extdata/OSD/B/BLOOM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/B/BLUEJAY.json
+++ b/inst/extdata/OSD/B/BLUEJAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BLUELIZARD.json
+++ b/inst/extdata/OSD/B/BLUELIZARD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BLUESPRIN.json
+++ b/inst/extdata/OSD/B/BLUESPRIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BOARDCAMP.json
+++ b/inst/extdata/OSD/B/BOARDCAMP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BOARDTREE.json
+++ b/inst/extdata/OSD/B/BOARDTREE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BOBERT.json
+++ b/inst/extdata/OSD/B/BOBERT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOBTAIL.json
+++ b/inst/extdata/OSD/B/BOBTAIL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOCA.json
+++ b/inst/extdata/OSD/B/BOCA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOCOX.json
+++ b/inst/extdata/OSD/B/BOCOX.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/B/BOETTCHER.json
+++ b/inst/extdata/OSD/B/BOETTCHER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BOGOSLOF.json
+++ b/inst/extdata/OSD/B/BOGOSLOF.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOLLETTO.json
+++ b/inst/extdata/OSD/B/BOLLETTO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOLTUS.json
+++ b/inst/extdata/OSD/B/BOLTUS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BON.json
+++ b/inst/extdata/OSD/B/BON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BONDRANCH.json
+++ b/inst/extdata/OSD/B/BONDRANCH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BONEDRAW.json
+++ b/inst/extdata/OSD/B/BONEDRAW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BONESTEEL.json
+++ b/inst/extdata/OSD/B/BONESTEEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly, very poorly"
       }
     ]

--- a/inst/extdata/OSD/B/BONESTEEL.json
+++ b/inst/extdata/OSD/B/BONESTEEL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": "very poorly and poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BONNIE.json
+++ b/inst/extdata/OSD/B/BONNIE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BONSALL.json
+++ b/inst/extdata/OSD/B/BONSALL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BONWIER.json
+++ b/inst/extdata/OSD/B/BONWIER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOOKER.json
+++ b/inst/extdata/OSD/B/BOOKER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOONTON.json
+++ b/inst/extdata/OSD/B/BOONTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BORDEAUX.json
+++ b/inst/extdata/OSD/B/BORDEAUX.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BORDEN.json
+++ b/inst/extdata/OSD/B/BORDEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BORREGO.json
+++ b/inst/extdata/OSD/B/BORREGO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BORUFF.json
+++ b/inst/extdata/OSD/B/BORUFF.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and somewhat poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BORUP.json
+++ b/inst/extdata/OSD/B/BORUP.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOSANKO.json
+++ b/inst/extdata/OSD/B/BOSANKO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BOSCAWEN.json
+++ b/inst/extdata/OSD/B/BOSCAWEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively and excessively",
-        "drainage_overview": "somewhat excessively and excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOSQUE.json
+++ b/inst/extdata/OSD/B/BOSQUE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BOTTLE.json
+++ b/inst/extdata/OSD/B/BOTTLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOUNDRIDGE.json
+++ b/inst/extdata/OSD/B/BOUNDRIDGE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOWBELLS.json
+++ b/inst/extdata/OSD/B/BOWBELLS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOWMANSVILLE.json
+++ b/inst/extdata/OSD/B/BOWMANSVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOXFORD.json
+++ b/inst/extdata/OSD/B/BOXFORD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOYLE.json
+++ b/inst/extdata/OSD/B/BOYLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "excessively"
       }
     ]

--- a/inst/extdata/OSD/B/BOYSEN.json
+++ b/inst/extdata/OSD/B/BOYSEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BOZE.json
+++ b/inst/extdata/OSD/B/BOZE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BOZEMAN.json
+++ b/inst/extdata/OSD/B/BOZEMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BRADSHAW.json
+++ b/inst/extdata/OSD/B/BRADSHAW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BRAF.json
+++ b/inst/extdata/OSD/B/BRAF.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively or excessively",
-        "drainage_overview": "somewhat excessively or excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BRAMAN.json
+++ b/inst/extdata/OSD/B/BRAMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BRAMLET.json
+++ b/inst/extdata/OSD/B/BRAMLET.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BRANDYWINE.json
+++ b/inst/extdata/OSD/B/BRANDYWINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BRANTEL.json
+++ b/inst/extdata/OSD/B/BRANTEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "excessively and somewhat excessively",
+        "drainage": "excessively, somewhat excessively",
         "drainage_overview": "excessively"
       }
     ]

--- a/inst/extdata/OSD/B/BRANYON.json
+++ b/inst/extdata/OSD/B/BRANYON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/B/BRASHEAR.json
+++ b/inst/extdata/OSD/B/BRASHEAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BREAKNECK.json
+++ b/inst/extdata/OSD/B/BREAKNECK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BRECKENRIDGE.json
+++ b/inst/extdata/OSD/B/BRECKENRIDGE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BREHM.json
+++ b/inst/extdata/OSD/B/BREHM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BRENDA.json
+++ b/inst/extdata/OSD/B/BRENDA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BRENTWOOD.json
+++ b/inst/extdata/OSD/B/BRENTWOOD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BRESSER.json
+++ b/inst/extdata/OSD/B/BRESSER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BREVORT.json
+++ b/inst/extdata/OSD/B/BREVORT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BREWER.json
+++ b/inst/extdata/OSD/B/BREWER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/B/BRIDGEHAMPTON.json
+++ b/inst/extdata/OSD/B/BRIDGEHAMPTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BRIEF.json
+++ b/inst/extdata/OSD/B/BRIEF.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BRIERY.json
+++ b/inst/extdata/OSD/B/BRIERY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BRIGGS.json
+++ b/inst/extdata/OSD/B/BRIGGS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BRINY.json
+++ b/inst/extdata/OSD/B/BRINY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BROADALBIN.json
+++ b/inst/extdata/OSD/B/BROADALBIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BROADAXE.json
+++ b/inst/extdata/OSD/B/BROADAXE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BROAD_CREEK.json
+++ b/inst/extdata/OSD/B/BROAD_CREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BROKIT.json
+++ b/inst/extdata/OSD/B/BROKIT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BROSELEY.json
+++ b/inst/extdata/OSD/B/BROSELEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
-        "drainage_overview": "well and somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BROSS.json
+++ b/inst/extdata/OSD/B/BROSS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well to moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BROWN.json
+++ b/inst/extdata/OSD/B/BROWN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BROWNRIGG.json
+++ b/inst/extdata/OSD/B/BROWNRIGG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BRUCE.json
+++ b/inst/extdata/OSD/B/BRUCE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BRUELLA.json
+++ b/inst/extdata/OSD/B/BRUELLA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BRUNI.json
+++ b/inst/extdata/OSD/B/BRUNI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BRYANT.json
+++ b/inst/extdata/OSD/B/BRYANT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BRYNWOOD.json
+++ b/inst/extdata/OSD/B/BRYNWOOD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly to poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/B/BUCHANAN.json
+++ b/inst/extdata/OSD/B/BUCHANAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BUCHENAU.json
+++ b/inst/extdata/OSD/B/BUCHENAU.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BUCKHOUSE.json
+++ b/inst/extdata/OSD/B/BUCKHOUSE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BUCKSKIN.json
+++ b/inst/extdata/OSD/B/BUCKSKIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BUELL.json
+++ b/inst/extdata/OSD/B/BUELL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BUFFORK.json
+++ b/inst/extdata/OSD/B/BUFFORK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BULL.json
+++ b/inst/extdata/OSD/B/BULL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BULLBASIN.json
+++ b/inst/extdata/OSD/B/BULLBASIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/B/BULLCREEK.json
+++ b/inst/extdata/OSD/B/BULLCREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BULLFOR.json
+++ b/inst/extdata/OSD/B/BULLFOR.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BULLROAR.json
+++ b/inst/extdata/OSD/B/BULLROAR.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BURCHAM.json
+++ b/inst/extdata/OSD/B/BURCHAM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BURGESS.json
+++ b/inst/extdata/OSD/B/BURGESS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BURGI.json
+++ b/inst/extdata/OSD/B/BURGI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/B/BURKE.json
+++ b/inst/extdata/OSD/B/BURKE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BURLEIGH.json
+++ b/inst/extdata/OSD/B/BURLEIGH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BURLESON.json
+++ b/inst/extdata/OSD/B/BURLESON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/B/BURLINGAME.json
+++ b/inst/extdata/OSD/B/BURLINGAME.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BURNTFLAT.json
+++ b/inst/extdata/OSD/B/BURNTFLAT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BURNTSHACK.json
+++ b/inst/extdata/OSD/B/BURNTSHACK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BURROIN.json
+++ b/inst/extdata/OSD/B/BURROIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BUSHER.json
+++ b/inst/extdata/OSD/B/BUSHER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BUSTLE.json
+++ b/inst/extdata/OSD/B/BUSTLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BUTCHE.json
+++ b/inst/extdata/OSD/B/BUTCHE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BUTTERFIELD.json
+++ b/inst/extdata/OSD/B/BUTTERFIELD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/B/BUTTERMILK.json
+++ b/inst/extdata/OSD/B/BUTTERMILK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/B/BUTTONWOOD.json
+++ b/inst/extdata/OSD/B/BUTTONWOOD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/B/BYRNIE.json
+++ b/inst/extdata/OSD/B/BYRNIE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CABELL.json
+++ b/inst/extdata/OSD/C/CABELL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CABEZON.json
+++ b/inst/extdata/OSD/C/CABEZON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CABINCREEK.json
+++ b/inst/extdata/OSD/C/CABINCREEK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CABLE.json
+++ b/inst/extdata/OSD/C/CABLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CACHE.json
+++ b/inst/extdata/OSD/C/CACHE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CACIQUE.json
+++ b/inst/extdata/OSD/C/CACIQUE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CADDO.json
+++ b/inst/extdata/OSD/C/CADDO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CAFFEY.json
+++ b/inst/extdata/OSD/C/CAFFEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CALABAR.json
+++ b/inst/extdata/OSD/C/CALABAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CALAMINE.json
+++ b/inst/extdata/OSD/C/CALAMINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CALAMITY.json
+++ b/inst/extdata/OSD/C/CALAMITY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CALCO.json
+++ b/inst/extdata/OSD/C/CALCO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CALERA.json
+++ b/inst/extdata/OSD/C/CALERA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CALICOTT.json
+++ b/inst/extdata/OSD/C/CALICOTT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively to excessively",
+        "drainage": "excessively, somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/C/CALIFON.json
+++ b/inst/extdata/OSD/C/CALIFON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CALKINS.json
+++ b/inst/extdata/OSD/C/CALKINS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CALLEGUAS.json
+++ b/inst/extdata/OSD/C/CALLEGUAS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CALMAR.json
+++ b/inst/extdata/OSD/C/CALMAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CALVERTON.json
+++ b/inst/extdata/OSD/C/CALVERTON.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CAMBERN.json
+++ b/inst/extdata/OSD/C/CAMBERN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CAMTOWN.json
+++ b/inst/extdata/OSD/C/CAMTOWN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CANANDAIGUA.json
+++ b/inst/extdata/OSD/C/CANANDAIGUA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CANASERAGA.json
+++ b/inst/extdata/OSD/C/CANASERAGA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CANAVERAL.json
+++ b/inst/extdata/OSD/C/CANAVERAL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to moderately well",
-        "drainage_overview": "somewhat poorly to moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CANEEK.json
+++ b/inst/extdata/OSD/C/CANEEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CANEYVILLE.json
+++ b/inst/extdata/OSD/C/CANEYVILLE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CANEZ.json
+++ b/inst/extdata/OSD/C/CANEZ.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CANISTEO.json
+++ b/inst/extdata/OSD/C/CANISTEO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CANLON.json
+++ b/inst/extdata/OSD/C/CANLON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CANTLE.json
+++ b/inst/extdata/OSD/C/CANTLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and somewhat poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CANYON.json
+++ b/inst/extdata/OSD/C/CANYON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CANYONSPRING.json
+++ b/inst/extdata/OSD/C/CANYONSPRING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CAPAY.json
+++ b/inst/extdata/OSD/C/CAPAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CAPE.json
+++ b/inst/extdata/OSD/C/CAPE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CAPITAN.json
+++ b/inst/extdata/OSD/C/CAPITAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CAPITOLA.json
+++ b/inst/extdata/OSD/C/CAPITOLA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CAPULIN.json
+++ b/inst/extdata/OSD/C/CAPULIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CARBIKA.json
+++ b/inst/extdata/OSD/C/CARBIKA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CARDIFF.json
+++ b/inst/extdata/OSD/C/CARDIFF.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CARGILL.json
+++ b/inst/extdata/OSD/C/CARGILL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CARIBOUCREEK.json
+++ b/inst/extdata/OSD/C/CARIBOUCREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CARLITO.json
+++ b/inst/extdata/OSD/C/CARLITO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CARLSBAD.json
+++ b/inst/extdata/OSD/C/CARLSBAD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CARMODY.json
+++ b/inst/extdata/OSD/C/CARMODY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CARR.json
+++ b/inst/extdata/OSD/C/CARR.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CARROLLTON.json
+++ b/inst/extdata/OSD/C/CARROLLTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CARTER.json
+++ b/inst/extdata/OSD/C/CARTER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CARUSO.json
+++ b/inst/extdata/OSD/C/CARUSO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CARWAY.json
+++ b/inst/extdata/OSD/C/CARWAY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CARYVILLE.json
+++ b/inst/extdata/OSD/C/CARYVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CASTAIC.json
+++ b/inst/extdata/OSD/C/CASTAIC.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CASTEPHEN.json
+++ b/inst/extdata/OSD/C/CASTEPHEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CASTO.json
+++ b/inst/extdata/OSD/C/CASTO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CASUSE.json
+++ b/inst/extdata/OSD/C/CASUSE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CATALPA.json
+++ b/inst/extdata/OSD/C/CATALPA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to moderately well",
-        "drainage_overview": "somewhat poorly to moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CATAMOUNT.json
+++ b/inst/extdata/OSD/C/CATAMOUNT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively or somewhat excessively",
-        "drainage_overview": "excessively or somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CATHEDRAL.json
+++ b/inst/extdata/OSD/C/CATHEDRAL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CATUNA.json
+++ b/inst/extdata/OSD/C/CATUNA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CAVAL.json
+++ b/inst/extdata/OSD/C/CAVAL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CAVENDISH.json
+++ b/inst/extdata/OSD/C/CAVENDISH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CAVESPRING.json
+++ b/inst/extdata/OSD/C/CAVESPRING.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CAVOUR.json
+++ b/inst/extdata/OSD/C/CAVOUR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CEBANA.json
+++ b/inst/extdata/OSD/C/CEBANA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CELESTE.json
+++ b/inst/extdata/OSD/C/CELESTE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CENCOVE.json
+++ b/inst/extdata/OSD/C/CENCOVE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CENTENARY.json
+++ b/inst/extdata/OSD/C/CENTENARY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CENTER.json
+++ b/inst/extdata/OSD/C/CENTER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/C/CENTINELA.json
+++ b/inst/extdata/OSD/C/CENTINELA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CERLIN.json
+++ b/inst/extdata/OSD/C/CERLIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CERRILLOS.json
+++ b/inst/extdata/OSD/C/CERRILLOS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CERRO.json
+++ b/inst/extdata/OSD/C/CERRO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CESTNIK.json
+++ b/inst/extdata/OSD/C/CESTNIK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CHAFFEE.json
+++ b/inst/extdata/OSD/C/CHAFFEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
-        "drainage_overview": "poorly to somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHAIRES.json
+++ b/inst/extdata/OSD/C/CHAIRES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHAMBERINO.json
+++ b/inst/extdata/OSD/C/CHAMBERINO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CHAMPION.json
+++ b/inst/extdata/OSD/C/CHAMPION.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHAMPLAIN.json
+++ b/inst/extdata/OSD/C/CHAMPLAIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively and somewhat excessively",
-        "drainage_overview": "excessively to somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHANCE.json
+++ b/inst/extdata/OSD/C/CHANCE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CHANCELLOR.json
+++ b/inst/extdata/OSD/C/CHANCELLOR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
-        "drainage_overview": "somewhat poorly and poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHANTILLY.json
+++ b/inst/extdata/OSD/C/CHANTILLY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CHARITY.json
+++ b/inst/extdata/OSD/C/CHARITY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHARLOS.json
+++ b/inst/extdata/OSD/C/CHARLOS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CHASE.json
+++ b/inst/extdata/OSD/C/CHASE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": "somewhat poorly"
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHASE.json
+++ b/inst/extdata/OSD/C/CHASE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": "moderately well, somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CHATHAM.json
+++ b/inst/extdata/OSD/C/CHATHAM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHAUSSE.json
+++ b/inst/extdata/OSD/C/CHAUSSE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHEBOYGAN.json
+++ b/inst/extdata/OSD/C/CHEBOYGAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHEEKTOWAGA.json
+++ b/inst/extdata/OSD/C/CHEEKTOWAGA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHENANGO.json
+++ b/inst/extdata/OSD/C/CHENANGO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
-        "drainage_overview": "well and somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHESTERTON.json
+++ b/inst/extdata/OSD/C/CHESTERTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "moderately well",
+        "drainage_overview": "moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHIEFLAND.json
+++ b/inst/extdata/OSD/C/CHIEFLAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
-        "drainage_overview": "moderately well or well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHILKOOT.json
+++ b/inst/extdata/OSD/C/CHILKOOT.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHILSON.json
+++ b/inst/extdata/OSD/C/CHILSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CHINCHALLO.json
+++ b/inst/extdata/OSD/C/CHINCHALLO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHINO.json
+++ b/inst/extdata/OSD/C/CHINO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CHIPPEWA.json
+++ b/inst/extdata/OSD/C/CHIPPEWA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHRISTIAN.json
+++ b/inst/extdata/OSD/C/CHRISTIAN.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHRISTIANBURG.json
+++ b/inst/extdata/OSD/C/CHRISTIANBURG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHUBBFLAT.json
+++ b/inst/extdata/OSD/C/CHUBBFLAT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CHUGTER.json
+++ b/inst/extdata/OSD/C/CHUGTER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CHUMMY.json
+++ b/inst/extdata/OSD/C/CHUMMY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CHUNILNA.json
+++ b/inst/extdata/OSD/C/CHUNILNA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CHURCH.json
+++ b/inst/extdata/OSD/C/CHURCH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CHURN.json
+++ b/inst/extdata/OSD/C/CHURN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CID.json
+++ b/inst/extdata/OSD/C/CID.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CIENO.json
+++ b/inst/extdata/OSD/C/CIENO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CINDERHURST.json
+++ b/inst/extdata/OSD/C/CINDERHURST.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CINDERSPRING.json
+++ b/inst/extdata/OSD/C/CINDERSPRING.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CIPRE.json
+++ b/inst/extdata/OSD/C/CIPRE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CIRCLEVILLE.json
+++ b/inst/extdata/OSD/C/CIRCLEVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CLAIRETTE.json
+++ b/inst/extdata/OSD/C/CLAIRETTE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/C/CLAPHAM.json
+++ b/inst/extdata/OSD/C/CLAPHAM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/C/CLARA.json
+++ b/inst/extdata/OSD/C/CLARA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CLARKELEN.json
+++ b/inst/extdata/OSD/C/CLARKELEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat excessively",
-        "drainage_overview": "moderately well or somewhat excessively"
+        "drainage": "somewhat excessively, well, moderately well",
+        "drainage_overview": "somewhat excessively, well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CLARNO.json
+++ b/inst/extdata/OSD/C/CLARNO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CLATO.json
+++ b/inst/extdata/OSD/C/CLATO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CLEARWATER.json
+++ b/inst/extdata/OSD/C/CLEARWATER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CLEMENTSVILLE.json
+++ b/inst/extdata/OSD/C/CLEMENTSVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CLIFFHOUSE.json
+++ b/inst/extdata/OSD/C/CLIFFHOUSE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CLIFTERSON.json
+++ b/inst/extdata/OSD/C/CLIFTERSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/C/CLIFTY.json
+++ b/inst/extdata/OSD/C/CLIFTY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CLIMARA.json
+++ b/inst/extdata/OSD/C/CLIMARA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CLIME.json
+++ b/inst/extdata/OSD/C/CLIME.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CLINGMAN.json
+++ b/inst/extdata/OSD/C/CLINGMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CLODINE.json
+++ b/inst/extdata/OSD/C/CLODINE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CLOQUATO.json
+++ b/inst/extdata/OSD/C/CLOQUATO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CLOUGH.json
+++ b/inst/extdata/OSD/C/CLOUGH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CLOVER_SPRINGS.json
+++ b/inst/extdata/OSD/C/CLOVER_SPRINGS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/C/CLOWERS.json
+++ b/inst/extdata/OSD/C/CLOWERS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CLYDE.json
+++ b/inst/extdata/OSD/C/CLYDE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COACHELLA.json
+++ b/inst/extdata/OSD/C/COACHELLA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COALIAMS.json
+++ b/inst/extdata/OSD/C/COALIAMS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COALVALE.json
+++ b/inst/extdata/OSD/C/COALVALE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COARDS.json
+++ b/inst/extdata/OSD/C/COARDS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COBBLETOP.json
+++ b/inst/extdata/OSD/C/COBBLETOP.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COBEY.json
+++ b/inst/extdata/OSD/C/COBEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CODORUS.json
+++ b/inst/extdata/OSD/C/CODORUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COHAGEN.json
+++ b/inst/extdata/OSD/C/COHAGEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COHOCTAH.json
+++ b/inst/extdata/OSD/C/COHOCTAH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COKEVILLE.json
+++ b/inst/extdata/OSD/C/COKEVILLE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COLBY.json
+++ b/inst/extdata/OSD/C/COLBY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COLDCREEK.json
+++ b/inst/extdata/OSD/C/COLDCREEK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/COLLEGIATE.json
+++ b/inst/extdata/OSD/C/COLLEGIATE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
-        "drainage_overview": "poorly to somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COLLINSVILLE.json
+++ b/inst/extdata/OSD/C/COLLINSVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COLMOR.json
+++ b/inst/extdata/OSD/C/COLMOR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/COLOMA.json
+++ b/inst/extdata/OSD/C/COLOMA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COLONIE.json
+++ b/inst/extdata/OSD/C/COLONIE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COLOROCK.json
+++ b/inst/extdata/OSD/C/COLOROCK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/COLOSSE.json
+++ b/inst/extdata/OSD/C/COLOSSE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively and somewhat excessively",
-        "drainage_overview": "excessively and somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COLVIN.json
+++ b/inst/extdata/OSD/C/COLVIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COLWOOD.json
+++ b/inst/extdata/OSD/C/COLWOOD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COLY.json
+++ b/inst/extdata/OSD/C/COLY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/COMETA.json
+++ b/inst/extdata/OSD/C/COMETA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
-        "drainage_overview": "moderately well or well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COMFORT.json
+++ b/inst/extdata/OSD/C/COMFORT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/COMFREY.json
+++ b/inst/extdata/OSD/C/COMFREY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COMODORE.json
+++ b/inst/extdata/OSD/C/COMODORE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CONANT.json
+++ b/inst/extdata/OSD/C/CONANT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CONCEPCION.json
+++ b/inst/extdata/OSD/C/CONCEPCION.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/C/CONE.json
+++ b/inst/extdata/OSD/C/CONE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CONGAREE.json
+++ b/inst/extdata/OSD/C/CONGAREE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CONI.json
+++ b/inst/extdata/OSD/C/CONI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CONNEAUT.json
+++ b/inst/extdata/OSD/C/CONNEAUT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and somewhat poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CONNER.json
+++ b/inst/extdata/OSD/C/CONNER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CONNERIDGE.json
+++ b/inst/extdata/OSD/C/CONNERIDGE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CONOTTON.json
+++ b/inst/extdata/OSD/C/CONOTTON.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CONOWINGO.json
+++ b/inst/extdata/OSD/C/CONOWINGO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CONROE.json
+++ b/inst/extdata/OSD/C/CONROE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/C/CONTEE.json
+++ b/inst/extdata/OSD/C/CONTEE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CONTEES_WHARF.json
+++ b/inst/extdata/OSD/C/CONTEES_WHARF.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CONTIDE.json
+++ b/inst/extdata/OSD/C/CONTIDE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CONTRA_COSTA.json
+++ b/inst/extdata/OSD/C/CONTRA_COSTA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/COOK.json
+++ b/inst/extdata/OSD/C/COOK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/C/COOKCREEK.json
+++ b/inst/extdata/OSD/C/COOKCREEK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COOMBS.json
+++ b/inst/extdata/OSD/C/COOMBS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CORA.json
+++ b/inst/extdata/OSD/C/CORA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "very poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CORDES.json
+++ b/inst/extdata/OSD/C/CORDES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COREE.json
+++ b/inst/extdata/OSD/C/COREE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CORMANT.json
+++ b/inst/extdata/OSD/C/CORMANT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CORNING.json
+++ b/inst/extdata/OSD/C/CORNING.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well or moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CORNVILLE.json
+++ b/inst/extdata/OSD/C/CORNVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COROLLA.json
+++ b/inst/extdata/OSD/C/COROLLA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CORRECO.json
+++ b/inst/extdata/OSD/C/CORRECO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CORTLAND.json
+++ b/inst/extdata/OSD/C/CORTLAND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/COSKI.json
+++ b/inst/extdata/OSD/C/COSKI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/COTACO.json
+++ b/inst/extdata/OSD/C/COTACO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COTAY.json
+++ b/inst/extdata/OSD/C/COTAY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COTOPAXI.json
+++ b/inst/extdata/OSD/C/COTOPAXI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COTTMAN.json
+++ b/inst/extdata/OSD/C/COTTMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COTTONEVA.json
+++ b/inst/extdata/OSD/C/COTTONEVA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or moderately well",
-        "drainage_overview": "somewhat poorly or moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COTTONTHOMAS.json
+++ b/inst/extdata/OSD/C/COTTONTHOMAS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COTTONWOOD.json
+++ b/inst/extdata/OSD/C/COTTONWOOD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/COUCH.json
+++ b/inst/extdata/OSD/C/COUCH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/COUCHSACHRAGA.json
+++ b/inst/extdata/OSD/C/COUCHSACHRAGA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively and excessively",
-        "drainage_overview": "somewhat excessively and excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COUNCELOR.json
+++ b/inst/extdata/OSD/C/COUNCELOR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/COUNTERFEIT.json
+++ b/inst/extdata/OSD/C/COUNTERFEIT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/COUNTRYMAN.json
+++ b/inst/extdata/OSD/C/COUNTRYMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/C/COURT.json
+++ b/inst/extdata/OSD/C/COURT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/COVE.json
+++ b/inst/extdata/OSD/C/COVE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COVILLE.json
+++ b/inst/extdata/OSD/C/COVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/COWAN.json
+++ b/inst/extdata/OSD/C/COWAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COWARTS.json
+++ b/inst/extdata/OSD/C/COWARTS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COWCAMP.json
+++ b/inst/extdata/OSD/C/COWCAMP.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COWESTGLEN.json
+++ b/inst/extdata/OSD/C/COWESTGLEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COWETA.json
+++ b/inst/extdata/OSD/C/COWETA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COXPIN.json
+++ b/inst/extdata/OSD/C/COXPIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/C/COYNE.json
+++ b/inst/extdata/OSD/C/COYNE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COYOTEBLUFF.json
+++ b/inst/extdata/OSD/C/COYOTEBLUFF.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/COZAD.json
+++ b/inst/extdata/OSD/C/COZAD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CRAFT.json
+++ b/inst/extdata/OSD/C/CRAFT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CRAGOLA.json
+++ b/inst/extdata/OSD/C/CRAGOLA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CRAIGSVILLE.json
+++ b/inst/extdata/OSD/C/CRAIGSVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CRANDON_BEACH.json
+++ b/inst/extdata/OSD/C/CRANDON_BEACH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CRANFILL.json
+++ b/inst/extdata/OSD/C/CRANFILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CRANMORE.json
+++ b/inst/extdata/OSD/C/CRANMORE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CREEDMOOR.json
+++ b/inst/extdata/OSD/C/CREEDMOOR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CREIGHTON.json
+++ b/inst/extdata/OSD/C/CREIGHTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CRESBARD.json
+++ b/inst/extdata/OSD/C/CRESBARD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CRESTMAN.json
+++ b/inst/extdata/OSD/C/CRESTMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CRITCHELL.json
+++ b/inst/extdata/OSD/C/CRITCHELL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CROPLEY.json
+++ b/inst/extdata/OSD/C/CROPLEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CROSS.json
+++ b/inst/extdata/OSD/C/CROSS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CROSSPLAIN.json
+++ b/inst/extdata/OSD/C/CROSSPLAIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
-        "drainage_overview": "somewhat poorly and poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CROWFLATS.json
+++ b/inst/extdata/OSD/C/CROWFLATS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CROWHEART.json
+++ b/inst/extdata/OSD/C/CROWHEART.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly and poorly"
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CROWTHER.json
+++ b/inst/extdata/OSD/C/CROWTHER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CROW_HILL.json
+++ b/inst/extdata/OSD/C/CROW_HILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CRUSO.json
+++ b/inst/extdata/OSD/C/CRUSO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CRYSTALBUTTE.json
+++ b/inst/extdata/OSD/C/CRYSTALBUTTE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CUESTA.json
+++ b/inst/extdata/OSD/C/CUESTA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CUEVA.json
+++ b/inst/extdata/OSD/C/CUEVA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CUEVOLAND.json
+++ b/inst/extdata/OSD/C/CUEVOLAND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CULBERTSON.json
+++ b/inst/extdata/OSD/C/CULBERTSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CULLISON.json
+++ b/inst/extdata/OSD/C/CULLISON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CUMINVAR.json
+++ b/inst/extdata/OSD/C/CUMINVAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CUMMINGS.json
+++ b/inst/extdata/OSD/C/CUMMINGS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CUNDIYO.json
+++ b/inst/extdata/OSD/C/CUNDIYO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
-        "drainage_overview": "well and somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CUPOLA.json
+++ b/inst/extdata/OSD/C/CUPOLA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CURANT.json
+++ b/inst/extdata/OSD/C/CURANT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/C/CUSTCO.json
+++ b/inst/extdata/OSD/C/CUSTCO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/C/CYFAIR.json
+++ b/inst/extdata/OSD/C/CYFAIR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/C/CYNTHIANA.json
+++ b/inst/extdata/OSD/C/CYNTHIANA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/C/CYPRESS_LAKE.json
+++ b/inst/extdata/OSD/C/CYPRESS_LAKE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DACONO.json
+++ b/inst/extdata/OSD/D/DACONO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DACOSTA.json
+++ b/inst/extdata/OSD/D/DACOSTA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/D/DADINA.json
+++ b/inst/extdata/OSD/D/DADINA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DAGGERHILL.json
+++ b/inst/extdata/OSD/D/DAGGERHILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "excessively",
         "drainage_overview": "excessively"
       }
     ]

--- a/inst/extdata/OSD/D/DAGLUM.json
+++ b/inst/extdata/OSD/D/DAGLUM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DAILEY.json
+++ b/inst/extdata/OSD/D/DAILEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/D/DAIR.json
+++ b/inst/extdata/OSD/D/DAIR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DALBO.json
+++ b/inst/extdata/OSD/D/DALBO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DALIAN.json
+++ b/inst/extdata/OSD/D/DALIAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DANACOVE.json
+++ b/inst/extdata/OSD/D/DANACOVE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DANDREA.json
+++ b/inst/extdata/OSD/D/DANDREA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DANIELSON.json
+++ b/inst/extdata/OSD/D/DANIELSON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DANKO.json
+++ b/inst/extdata/OSD/D/DANKO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DANSKIN.json
+++ b/inst/extdata/OSD/D/DANSKIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DARKWOODS.json
+++ b/inst/extdata/OSD/D/DARKWOODS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DARNELL.json
+++ b/inst/extdata/OSD/D/DARNELL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "somewhat excessively, well"
       }
     ]

--- a/inst/extdata/OSD/D/DARNELL.json
+++ b/inst/extdata/OSD/D/DARNELL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DARRET.json
+++ b/inst/extdata/OSD/D/DARRET.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DARWIN.json
+++ b/inst/extdata/OSD/D/DARWIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DAST.json
+++ b/inst/extdata/OSD/D/DAST.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DAULTON.json
+++ b/inst/extdata/OSD/D/DAULTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DAVILLA.json
+++ b/inst/extdata/OSD/D/DAVILLA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/D/DAVIS.json
+++ b/inst/extdata/OSD/D/DAVIS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DEACON.json
+++ b/inst/extdata/OSD/D/DEACON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DEADMAN.json
+++ b/inst/extdata/OSD/D/DEADMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DEARDORF.json
+++ b/inst/extdata/OSD/D/DEARDORF.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DEBONE.json
+++ b/inst/extdata/OSD/D/DEBONE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DECK.json
+++ b/inst/extdata/OSD/D/DECK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DEERHEART.json
+++ b/inst/extdata/OSD/D/DEERHEART.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DEER_CREEK.json
+++ b/inst/extdata/OSD/D/DEER_CREEK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DEFORD.json
+++ b/inst/extdata/OSD/D/DEFORD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DEGARMO.json
+++ b/inst/extdata/OSD/D/DEGARMO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or somewhat poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DEGNER.json
+++ b/inst/extdata/OSD/D/DEGNER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DEKALB.json
+++ b/inst/extdata/OSD/D/DEKALB.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "excessively"
       }
     ]

--- a/inst/extdata/OSD/D/DELANCO.json
+++ b/inst/extdata/OSD/D/DELANCO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DELETE_MEII.json
+++ b/inst/extdata/OSD/D/DELETE_MEII.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DELFT.json
+++ b/inst/extdata/OSD/D/DELFT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/D/DELL.json
+++ b/inst/extdata/OSD/D/DELL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DELLEKER.json
+++ b/inst/extdata/OSD/D/DELLEKER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DELMA.json
+++ b/inst/extdata/OSD/D/DELMA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DELMITA.json
+++ b/inst/extdata/OSD/D/DELMITA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DELNORTE.json
+++ b/inst/extdata/OSD/D/DELNORTE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DELPIEDRA.json
+++ b/inst/extdata/OSD/D/DELPIEDRA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DELTASHORE.json
+++ b/inst/extdata/OSD/D/DELTASHORE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DEMAS.json
+++ b/inst/extdata/OSD/D/DEMAS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DEMONA.json
+++ b/inst/extdata/OSD/D/DEMONA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/D/DEMONTREVILLE.json
+++ b/inst/extdata/OSD/D/DEMONTREVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DENMARK.json
+++ b/inst/extdata/OSD/D/DENMARK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DENURE.json
+++ b/inst/extdata/OSD/D/DENURE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DENVER.json
+++ b/inst/extdata/OSD/D/DENVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DEROIN.json
+++ b/inst/extdata/OSD/D/DEROIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DERRICK.json
+++ b/inst/extdata/OSD/D/DERRICK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DERRYNANE.json
+++ b/inst/extdata/OSD/D/DERRYNANE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DESHLER.json
+++ b/inst/extdata/OSD/D/DESHLER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DES_MOINES.json
+++ b/inst/extdata/OSD/D/DES_MOINES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DETROIT.json
+++ b/inst/extdata/OSD/D/DETROIT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/D/DIAMOND_SPRINGS.json
+++ b/inst/extdata/OSD/D/DIAMOND_SPRINGS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DIMYAW.json
+++ b/inst/extdata/OSD/D/DIMYAW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DINKELMAN.json
+++ b/inst/extdata/OSD/D/DINKELMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DIPMAN.json
+++ b/inst/extdata/OSD/D/DIPMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or poorly",
-        "drainage_overview": "somewhat poorly or poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DISMALSWAMP.json
+++ b/inst/extdata/OSD/D/DISMALSWAMP.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DITCHCAMP.json
+++ b/inst/extdata/OSD/D/DITCHCAMP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DIXMONT.json
+++ b/inst/extdata/OSD/D/DIXMONT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DOBROW.json
+++ b/inst/extdata/OSD/D/DOBROW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to very poorly",
-        "drainage_overview": "poorly to very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DOCAS.json
+++ b/inst/extdata/OSD/D/DOCAS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DODGE.json
+++ b/inst/extdata/OSD/D/DODGE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DOGER.json
+++ b/inst/extdata/OSD/D/DOGER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DOLEKEI.json
+++ b/inst/extdata/OSD/D/DOLEKEI.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DOMO.json
+++ b/inst/extdata/OSD/D/DOMO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DONLONTON.json
+++ b/inst/extdata/OSD/D/DONLONTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DORCHEAT.json
+++ b/inst/extdata/OSD/D/DORCHEAT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/D/DORCHESTER.json
+++ b/inst/extdata/OSD/D/DORCHESTER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DORS.json
+++ b/inst/extdata/OSD/D/DORS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DOUGHSPON.json
+++ b/inst/extdata/OSD/D/DOUGHSPON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DOVRAY.json
+++ b/inst/extdata/OSD/D/DOVRAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DOWNATA.json
+++ b/inst/extdata/OSD/D/DOWNATA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DRA.json
+++ b/inst/extdata/OSD/D/DRA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DRAGLINE.json
+++ b/inst/extdata/OSD/D/DRAGLINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DRAKNAB.json
+++ b/inst/extdata/OSD/D/DRAKNAB.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or excessively",
-        "drainage_overview": "well or excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DRAYKE.json
+++ b/inst/extdata/OSD/D/DRAYKE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DREXEL.json
+++ b/inst/extdata/OSD/D/DREXEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DREYFOOS.json
+++ b/inst/extdata/OSD/D/DREYFOOS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "excessively",
         "drainage_overview": "excessively"
       }
     ]

--- a/inst/extdata/OSD/D/DRYBURG.json
+++ b/inst/extdata/OSD/D/DRYBURG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DRY_CREEK.json
+++ b/inst/extdata/OSD/D/DRY_CREEK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DUCKHILL.json
+++ b/inst/extdata/OSD/D/DUCKHILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DUDLEY.json
+++ b/inst/extdata/OSD/D/DUDLEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DUFFAU.json
+++ b/inst/extdata/OSD/D/DUFFAU.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DUFFER.json
+++ b/inst/extdata/OSD/D/DUFFER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DUFFYMONT.json
+++ b/inst/extdata/OSD/D/DUFFYMONT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DUFORT.json
+++ b/inst/extdata/OSD/D/DUFORT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DUFUR.json
+++ b/inst/extdata/OSD/D/DUFUR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DUKE.json
+++ b/inst/extdata/OSD/D/DUKE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DULLES.json
+++ b/inst/extdata/OSD/D/DULLES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DUNCAN.json
+++ b/inst/extdata/OSD/D/DUNCAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/D/DUNNING.json
+++ b/inst/extdata/OSD/D/DUNNING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly to poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DUNUL.json
+++ b/inst/extdata/OSD/D/DUNUL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DUPEE.json
+++ b/inst/extdata/OSD/D/DUPEE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DUROC.json
+++ b/inst/extdata/OSD/D/DUROC.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DURREO.json
+++ b/inst/extdata/OSD/D/DURREO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DUTCHMAN_POINT.json
+++ b/inst/extdata/OSD/D/DUTCHMAN_POINT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DUTTON.json
+++ b/inst/extdata/OSD/D/DUTTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/D/DUVALL_CREEK.json
+++ b/inst/extdata/OSD/D/DUVALL_CREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DU_PAGE.json
+++ b/inst/extdata/OSD/D/DU_PAGE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/D/DWIGHT.json
+++ b/inst/extdata/OSD/D/DWIGHT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/D/DYKE.json
+++ b/inst/extdata/OSD/D/DYKE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EAD.json
+++ b/inst/extdata/OSD/E/EAD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EAGAR.json
+++ b/inst/extdata/OSD/E/EAGAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EARP.json
+++ b/inst/extdata/OSD/E/EARP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EARSMAN.json
+++ b/inst/extdata/OSD/E/EARSMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EATON.json
+++ b/inst/extdata/OSD/E/EATON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EAUGALLIE.json
+++ b/inst/extdata/OSD/E/EAUGALLIE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EBA.json
+++ b/inst/extdata/OSD/E/EBA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EBBERT.json
+++ b/inst/extdata/OSD/E/EBBERT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ECKRANT.json
+++ b/inst/extdata/OSD/E/ECKRANT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EDA.json
+++ b/inst/extdata/OSD/E/EDA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/E/EDALGO.json
+++ b/inst/extdata/OSD/E/EDALGO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EDDY.json
+++ b/inst/extdata/OSD/E/EDDY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EDGAR.json
+++ b/inst/extdata/OSD/E/EDGAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/E/EDGEMERE.json
+++ b/inst/extdata/OSD/E/EDGEMERE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EDGEWATER.json
+++ b/inst/extdata/OSD/E/EDGEWATER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
-        "drainage_overview": "somewhat poorly to poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EDGEWOOD.json
+++ b/inst/extdata/OSD/E/EDGEWOOD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/E/EDMORE.json
+++ b/inst/extdata/OSD/E/EDMORE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EGAM.json
+++ b/inst/extdata/OSD/E/EGAM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EGAS.json
+++ b/inst/extdata/OSD/E/EGAS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EGGLAKE.json
+++ b/inst/extdata/OSD/E/EGGLAKE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EGHELM.json
+++ b/inst/extdata/OSD/E/EGHELM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EIELSON.json
+++ b/inst/extdata/OSD/E/EIELSON.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat poorly",
-        "drainage_overview": ""
+        "drainage_overview": "somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EITZEN.json
+++ b/inst/extdata/OSD/E/EITZEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EKAL.json
+++ b/inst/extdata/OSD/E/EKAL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/E/EKALAKA.json
+++ b/inst/extdata/OSD/E/EKALAKA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ELA.json
+++ b/inst/extdata/OSD/E/ELA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ELBAVILLE.json
+++ b/inst/extdata/OSD/E/ELBAVILLE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ELDER.json
+++ b/inst/extdata/OSD/E/ELDER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/ELEVA.json
+++ b/inst/extdata/OSD/E/ELEVA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ELKINS.json
+++ b/inst/extdata/OSD/E/ELKINS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ELKRIVER.json
+++ b/inst/extdata/OSD/E/ELKRIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ELKWALOW.json
+++ b/inst/extdata/OSD/E/ELKWALOW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or moderately well",
-        "drainage_overview": "somewhat poorly or moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ELLEDGE.json
+++ b/inst/extdata/OSD/E/ELLEDGE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ELLETT.json
+++ b/inst/extdata/OSD/E/ELLETT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/ELLISFORDE.json
+++ b/inst/extdata/OSD/E/ELLISFORDE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/ELSAH.json
+++ b/inst/extdata/OSD/E/ELSAH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ELTSAC.json
+++ b/inst/extdata/OSD/E/ELTSAC.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/ELVERS.json
+++ b/inst/extdata/OSD/E/ELVERS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EMBDEN.json
+++ b/inst/extdata/OSD/E/EMBDEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EMBRY.json
+++ b/inst/extdata/OSD/E/EMBRY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EMIGRANT.json
+++ b/inst/extdata/OSD/E/EMIGRANT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EMMET.json
+++ b/inst/extdata/OSD/E/EMMET.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EMOT.json
+++ b/inst/extdata/OSD/E/EMOT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EMPIRE.json
+++ b/inst/extdata/OSD/E/EMPIRE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/E/EMRICK.json
+++ b/inst/extdata/OSD/E/EMRICK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ENDEAVOR.json
+++ b/inst/extdata/OSD/E/ENDEAVOR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ENGLEWOOD.json
+++ b/inst/extdata/OSD/E/ENGLEWOOD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ENNING.json
+++ b/inst/extdata/OSD/E/ENNING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ENNIS.json
+++ b/inst/extdata/OSD/E/ENNIS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EPHRATA.json
+++ b/inst/extdata/OSD/E/EPHRATA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EPOUFETTE.json
+++ b/inst/extdata/OSD/E/EPOUFETTE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EPWORTH.json
+++ b/inst/extdata/OSD/E/EPWORTH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ERA.json
+++ b/inst/extdata/OSD/E/ERA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/ERIN.json
+++ b/inst/extdata/OSD/E/ERIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ERMATINGER.json
+++ b/inst/extdata/OSD/E/ERMATINGER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ERNEST.json
+++ b/inst/extdata/OSD/E/ERNEST.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ESCONDIDO.json
+++ b/inst/extdata/OSD/E/ESCONDIDO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/E/ESKIMINZIN.json
+++ b/inst/extdata/OSD/E/ESKIMINZIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/ESPARTO.json
+++ b/inst/extdata/OSD/E/ESPARTO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/E/ESPELIE.json
+++ b/inst/extdata/OSD/E/ESPELIE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ESSEVILLE.json
+++ b/inst/extdata/OSD/E/ESSEVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/ESSEXVILLE.json
+++ b/inst/extdata/OSD/E/ESSEXVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/ETHELMAN.json
+++ b/inst/extdata/OSD/E/ETHELMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/E/ETHETE.json
+++ b/inst/extdata/OSD/E/ETHETE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/ETTRICK.json
+++ b/inst/extdata/OSD/E/ETTRICK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/E/EUDORA.json
+++ b/inst/extdata/OSD/E/EUDORA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EUDORA.json
+++ b/inst/extdata/OSD/E/EUDORA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EUFAULA.json
+++ b/inst/extdata/OSD/E/EUFAULA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/E/EVA.json
+++ b/inst/extdata/OSD/E/EVA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/E/EVART.json
+++ b/inst/extdata/OSD/E/EVART.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EWAN.json
+++ b/inst/extdata/OSD/E/EWAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EXCELLO.json
+++ b/inst/extdata/OSD/E/EXCELLO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EXEL.json
+++ b/inst/extdata/OSD/E/EXEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/E/EXLINE.json
+++ b/inst/extdata/OSD/E/EXLINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or moderately well",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/E/EYERBOW.json
+++ b/inst/extdata/OSD/E/EYERBOW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/E/EZBIN.json
+++ b/inst/extdata/OSD/E/EZBIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FADDIN.json
+++ b/inst/extdata/OSD/F/FADDIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/F/FAIRBURN.json
+++ b/inst/extdata/OSD/F/FAIRBURN.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FAIRPORT.json
+++ b/inst/extdata/OSD/F/FAIRPORT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FAIRY.json
+++ b/inst/extdata/OSD/F/FAIRY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FAIRYDELL.json
+++ b/inst/extdata/OSD/F/FAIRYDELL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FALCON.json
+++ b/inst/extdata/OSD/F/FALCON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FALLEAF.json
+++ b/inst/extdata/OSD/F/FALLEAF.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FALLSAM.json
+++ b/inst/extdata/OSD/F/FALLSAM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FALULA.json
+++ b/inst/extdata/OSD/F/FALULA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FANCHER.json
+++ b/inst/extdata/OSD/F/FANCHER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FANNO.json
+++ b/inst/extdata/OSD/F/FANNO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FANU.json
+++ b/inst/extdata/OSD/F/FANU.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FARB.json
+++ b/inst/extdata/OSD/F/FARB.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively or somewhat excessively",
-        "drainage_overview": "excessively or somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FARGO.json
+++ b/inst/extdata/OSD/F/FARGO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FARISITA.json
+++ b/inst/extdata/OSD/F/FARISITA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FARMINGTON.json
+++ b/inst/extdata/OSD/F/FARMINGTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FARMSWORTH.json
+++ b/inst/extdata/OSD/F/FARMSWORTH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FARVIEW.json
+++ b/inst/extdata/OSD/F/FARVIEW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FATTIG.json
+++ b/inst/extdata/OSD/F/FATTIG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FAXON.json
+++ b/inst/extdata/OSD/F/FAXON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FEEDER.json
+++ b/inst/extdata/OSD/F/FEEDER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FELDA.json
+++ b/inst/extdata/OSD/F/FELDA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FELIX.json
+++ b/inst/extdata/OSD/F/FELIX.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/F/FELLOWSHIP.json
+++ b/inst/extdata/OSD/F/FELLOWSHIP.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FELTA.json
+++ b/inst/extdata/OSD/F/FELTA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/F/FELTHAM.json
+++ b/inst/extdata/OSD/F/FELTHAM.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FENANDER.json
+++ b/inst/extdata/OSD/F/FENANDER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FERNEY.json
+++ b/inst/extdata/OSD/F/FERNEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FERN_CLIFF.json
+++ b/inst/extdata/OSD/F/FERN_CLIFF.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/F/FERRIS.json
+++ b/inst/extdata/OSD/F/FERRIS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FIGGS.json
+++ b/inst/extdata/OSD/F/FIGGS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FILAREE.json
+++ b/inst/extdata/OSD/F/FILAREE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively to well",
-        "drainage_overview": "somewhat excessively to well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FILLEY.json
+++ b/inst/extdata/OSD/F/FILLEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FINN.json
+++ b/inst/extdata/OSD/F/FINN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FINNERTY.json
+++ b/inst/extdata/OSD/F/FINNERTY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/F/FIRMAGE.json
+++ b/inst/extdata/OSD/F/FIRMAGE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FIVELAKES.json
+++ b/inst/extdata/OSD/F/FIVELAKES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FIVEMILE.json
+++ b/inst/extdata/OSD/F/FIVEMILE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FIVES.json
+++ b/inst/extdata/OSD/F/FIVES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FLEISCHMANN.json
+++ b/inst/extdata/OSD/F/FLEISCHMANN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FLOM.json
+++ b/inst/extdata/OSD/F/FLOM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FLUETSCH.json
+++ b/inst/extdata/OSD/F/FLUETSCH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/F/FLYWAY.json
+++ b/inst/extdata/OSD/F/FLYWAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FOLA.json
+++ b/inst/extdata/OSD/F/FOLA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FONDIS.json
+++ b/inst/extdata/OSD/F/FONDIS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FOOLHEN.json
+++ b/inst/extdata/OSD/F/FOOLHEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FORADA.json
+++ b/inst/extdata/OSD/F/FORADA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FORT_NECK.json
+++ b/inst/extdata/OSD/F/FORT_NECK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FOSSUM.json
+++ b/inst/extdata/OSD/F/FOSSUM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FOSTER.json
+++ b/inst/extdata/OSD/F/FOSTER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/F/FOUNDEM.json
+++ b/inst/extdata/OSD/F/FOUNDEM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FOURME.json
+++ b/inst/extdata/OSD/F/FOURME.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FOURMILE.json
+++ b/inst/extdata/OSD/F/FOURMILE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FOUR_STAR.json
+++ b/inst/extdata/OSD/F/FOUR_STAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FOXWORTH.json
+++ b/inst/extdata/OSD/F/FOXWORTH.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "moderately well to somewhat excessively"
+        "drainage_overview": "somewhat excessively, well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FOX_CREEK.json
+++ b/inst/extdata/OSD/F/FOX_CREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FRAGUA.json
+++ b/inst/extdata/OSD/F/FRAGUA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively and well",
-        "drainage_overview": "somewhat excessively and well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FRANDSEN.json
+++ b/inst/extdata/OSD/F/FRANDSEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FREDON.json
+++ b/inst/extdata/OSD/F/FREDON.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FRENCH.json
+++ b/inst/extdata/OSD/F/FRENCH.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FREZNIK.json
+++ b/inst/extdata/OSD/F/FREZNIK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FRIANA.json
+++ b/inst/extdata/OSD/F/FRIANA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FRIBERG.json
+++ b/inst/extdata/OSD/F/FRIBERG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FRIO.json
+++ b/inst/extdata/OSD/F/FRIO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FROBERG.json
+++ b/inst/extdata/OSD/F/FROBERG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FRUITLAND.json
+++ b/inst/extdata/OSD/F/FRUITLAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FRYDEK.json
+++ b/inst/extdata/OSD/F/FRYDEK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/F/FRYE.json
+++ b/inst/extdata/OSD/F/FRYE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FRYREAR.json
+++ b/inst/extdata/OSD/F/FRYREAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FUERA.json
+++ b/inst/extdata/OSD/F/FUERA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/F/FULCHER.json
+++ b/inst/extdata/OSD/F/FULCHER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/F/FUNSTON.json
+++ b/inst/extdata/OSD/F/FUNSTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FURY.json
+++ b/inst/extdata/OSD/F/FURY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/F/FUSULINA.json
+++ b/inst/extdata/OSD/F/FUSULINA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GABBS.json
+++ b/inst/extdata/OSD/G/GABBS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GABEL.json
+++ b/inst/extdata/OSD/G/GABEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GAINES.json
+++ b/inst/extdata/OSD/G/GAINES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GALOO.json
+++ b/inst/extdata/OSD/G/GALOO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively",
-        "drainage_overview": "somewhat excessively to excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GALWAY.json
+++ b/inst/extdata/OSD/G/GALWAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GANNETT.json
+++ b/inst/extdata/OSD/G/GANNETT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GAP.json
+++ b/inst/extdata/OSD/G/GAP.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GAPPMAYER.json
+++ b/inst/extdata/OSD/G/GAPPMAYER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GARBER.json
+++ b/inst/extdata/OSD/G/GARBER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GARDENA.json
+++ b/inst/extdata/OSD/G/GARDENA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GARDENCITY.json
+++ b/inst/extdata/OSD/G/GARDENCITY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GARDINER.json
+++ b/inst/extdata/OSD/G/GARDINER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GAREY.json
+++ b/inst/extdata/OSD/G/GAREY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GARITA.json
+++ b/inst/extdata/OSD/G/GARITA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GARR.json
+++ b/inst/extdata/OSD/G/GARR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GARRETT.json
+++ b/inst/extdata/OSD/G/GARRETT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GARSID.json
+++ b/inst/extdata/OSD/G/GARSID.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GARVEN.json
+++ b/inst/extdata/OSD/G/GARVEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GARVIN.json
+++ b/inst/extdata/OSD/G/GARVIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/G/GARWOOD.json
+++ b/inst/extdata/OSD/G/GARWOOD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/G/GARZA.json
+++ b/inst/extdata/OSD/G/GARZA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GAS_CREEK.json
+++ b/inst/extdata/OSD/G/GAS_CREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
-        "drainage_overview": "poorly or somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GATES.json
+++ b/inst/extdata/OSD/G/GATES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GATESON.json
+++ b/inst/extdata/OSD/G/GATESON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GATEVIEW.json
+++ b/inst/extdata/OSD/G/GATEVIEW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GAY.json
+++ b/inst/extdata/OSD/G/GAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GAYLESVILLE.json
+++ b/inst/extdata/OSD/G/GAYLESVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
-        "drainage_overview": "poorly to somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GAYLORD.json
+++ b/inst/extdata/OSD/G/GAYLORD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GENEVA.json
+++ b/inst/extdata/OSD/G/GENEVA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GERLANE.json
+++ b/inst/extdata/OSD/G/GERLANE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GETZVILLE.json
+++ b/inst/extdata/OSD/G/GETZVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GIARCH.json
+++ b/inst/extdata/OSD/G/GIARCH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GIBBLER.json
+++ b/inst/extdata/OSD/G/GIBBLER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GIBRALTAR.json
+++ b/inst/extdata/OSD/G/GIBRALTAR.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GILCO.json
+++ b/inst/extdata/OSD/G/GILCO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GILCREST.json
+++ b/inst/extdata/OSD/G/GILCREST.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GILFORD.json
+++ b/inst/extdata/OSD/G/GILFORD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GILLAND.json
+++ b/inst/extdata/OSD/G/GILLAND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GILLETT_GROVE.json
+++ b/inst/extdata/OSD/G/GILLETT_GROVE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GIRARDOT.json
+++ b/inst/extdata/OSD/G/GIRARDOT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/G/GLADEWATER.json
+++ b/inst/extdata/OSD/G/GLADEWATER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly, poorly, very poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/G/GLAWE.json
+++ b/inst/extdata/OSD/G/GLAWE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GLAZE.json
+++ b/inst/extdata/OSD/G/GLAZE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GLEAN.json
+++ b/inst/extdata/OSD/G/GLEAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GLEASON.json
+++ b/inst/extdata/OSD/G/GLEASON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GLENDIVE.json
+++ b/inst/extdata/OSD/G/GLENDIVE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
-        "drainage_overview": "moderately well or well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GLENDORA.json
+++ b/inst/extdata/OSD/G/GLENDORA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GLENFLORA.json
+++ b/inst/extdata/OSD/G/GLENFLORA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GLENTON.json
+++ b/inst/extdata/OSD/G/GLENTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GLENVILLE.json
+++ b/inst/extdata/OSD/G/GLENVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GLORIA.json
+++ b/inst/extdata/OSD/G/GLORIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GOESSEL.json
+++ b/inst/extdata/OSD/G/GOESSEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/G/GOLDENBELL.json
+++ b/inst/extdata/OSD/G/GOLDENBELL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GOLDHEAD.json
+++ b/inst/extdata/OSD/G/GOLDHEAD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GOLDSTON.json
+++ b/inst/extdata/OSD/G/GOLDSTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GOLD_CREEK.json
+++ b/inst/extdata/OSD/G/GOLD_CREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GOLETA.json
+++ b/inst/extdata/OSD/G/GOLETA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GOLTRY.json
+++ b/inst/extdata/OSD/G/GOLTRY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/G/GOODELL.json
+++ b/inst/extdata/OSD/G/GOODELL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GOODHOPE.json
+++ b/inst/extdata/OSD/G/GOODHOPE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GOOSEFLATS.json
+++ b/inst/extdata/OSD/G/GOOSEFLATS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GOOSE_CREEK.json
+++ b/inst/extdata/OSD/G/GOOSE_CREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GORING.json
+++ b/inst/extdata/OSD/G/GORING.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GORMAN.json
+++ b/inst/extdata/OSD/G/GORMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GOSHUTE.json
+++ b/inst/extdata/OSD/G/GOSHUTE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GOTHO.json
+++ b/inst/extdata/OSD/G/GOTHO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GOURLEY.json
+++ b/inst/extdata/OSD/G/GOURLEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GOUVERNEUR.json
+++ b/inst/extdata/OSD/G/GOUVERNEUR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively",
-        "drainage_overview": "excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GOWKER.json
+++ b/inst/extdata/OSD/G/GOWKER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/G/GRACEVILLE.json
+++ b/inst/extdata/OSD/G/GRACEVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRAHAM.json
+++ b/inst/extdata/OSD/G/GRAHAM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GRAIL.json
+++ b/inst/extdata/OSD/G/GRAIL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRANBURY.json
+++ b/inst/extdata/OSD/G/GRANBURY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/G/GRANBY.json
+++ b/inst/extdata/OSD/G/GRANBY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRANDVIEW.json
+++ b/inst/extdata/OSD/G/GRANDVIEW.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "moderately well and well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRANGE.json
+++ b/inst/extdata/OSD/G/GRANGE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and somewhat poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRANO.json
+++ b/inst/extdata/OSD/G/GRANO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRANT.json
+++ b/inst/extdata/OSD/G/GRANT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GRASSLAND.json
+++ b/inst/extdata/OSD/G/GRASSLAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRASSNA.json
+++ b/inst/extdata/OSD/G/GRASSNA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRASSY_BUTTE.json
+++ b/inst/extdata/OSD/G/GRASSY_BUTTE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively or excessively",
-        "drainage_overview": "somewhat excessively or excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRAYLOCK.json
+++ b/inst/extdata/OSD/G/GRAYLOCK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRAYPOINT.json
+++ b/inst/extdata/OSD/G/GRAYPOINT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GRAYSLAKE.json
+++ b/inst/extdata/OSD/G/GRAYSLAKE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/G/GREANEY.json
+++ b/inst/extdata/OSD/G/GREANEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GREAT_BAY.json
+++ b/inst/extdata/OSD/G/GREAT_BAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GREAT_DITCH.json
+++ b/inst/extdata/OSD/G/GREAT_DITCH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GREENLEAF.json
+++ b/inst/extdata/OSD/G/GREENLEAF.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GREENSON.json
+++ b/inst/extdata/OSD/G/GREENSON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GREEN_RIVER.json
+++ b/inst/extdata/OSD/G/GREEN_RIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GREYBACK.json
+++ b/inst/extdata/OSD/G/GREYBACK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively to excessively",
-        "drainage_overview": "somewhat excessively or excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GREYS.json
+++ b/inst/extdata/OSD/G/GREYS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GRIEVES.json
+++ b/inst/extdata/OSD/G/GRIEVES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRINDALL.json
+++ b/inst/extdata/OSD/G/GRINDALL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/G/GRINDER.json
+++ b/inst/extdata/OSD/G/GRINDER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GRINTER.json
+++ b/inst/extdata/OSD/G/GRINTER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GRIVER.json
+++ b/inst/extdata/OSD/G/GRIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or somewhat poorly",
-        "drainage_overview": "poorly or somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GROSS.json
+++ b/inst/extdata/OSD/G/GROSS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GROUSECREEK.json
+++ b/inst/extdata/OSD/G/GROUSECREEK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GROWTON.json
+++ b/inst/extdata/OSD/G/GROWTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GRYGLA.json
+++ b/inst/extdata/OSD/G/GRYGLA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GUAJE.json
+++ b/inst/extdata/OSD/G/GUAJE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GUANELLA.json
+++ b/inst/extdata/OSD/G/GUANELLA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GUELPH.json
+++ b/inst/extdata/OSD/G/GUELPH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GUFF.json
+++ b/inst/extdata/OSD/G/GUFF.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GUFFIN.json
+++ b/inst/extdata/OSD/G/GUFFIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GUGUAK.json
+++ b/inst/extdata/OSD/G/GUGUAK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/G/GULF.json
+++ b/inst/extdata/OSD/G/GULF.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GUMZ.json
+++ b/inst/extdata/OSD/G/GUMZ.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GUNBARREL.json
+++ b/inst/extdata/OSD/G/GUNBARREL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
-        "drainage_overview": "somewhat poorly to poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GUNNEL.json
+++ b/inst/extdata/OSD/G/GUNNEL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GUS.json
+++ b/inst/extdata/OSD/G/GUS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "very poorly",
-        "drainage_overview": "poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GUS.json
+++ b/inst/extdata/OSD/G/GUS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly, very poorly"
       }
     ]

--- a/inst/extdata/OSD/G/GUSTIN.json
+++ b/inst/extdata/OSD/G/GUSTIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GUY.json
+++ b/inst/extdata/OSD/G/GUY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/G/GUYTON.json
+++ b/inst/extdata/OSD/G/GUYTON.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/G/GYSTRUM.json
+++ b/inst/extdata/OSD/G/GYSTRUM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HAGENBARTH.json
+++ b/inst/extdata/OSD/H/HAGENBARTH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HAGGATT.json
+++ b/inst/extdata/OSD/H/HAGGATT.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HAIGHTS.json
+++ b/inst/extdata/OSD/H/HAIGHTS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HAIGLER.json
+++ b/inst/extdata/OSD/H/HAIGLER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/H/HALII.json
+++ b/inst/extdata/OSD/H/HALII.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
+        "drainage": "well, moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/H/HALL.json
+++ b/inst/extdata/OSD/H/HALL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HALLANDALE.json
+++ b/inst/extdata/OSD/H/HALLANDALE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly to poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HALLET.json
+++ b/inst/extdata/OSD/H/HALLET.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/H/HALLISON.json
+++ b/inst/extdata/OSD/H/HALLISON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HAMEL.json
+++ b/inst/extdata/OSD/H/HAMEL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HANALEI.json
+++ b/inst/extdata/OSD/H/HANALEI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HANLY.json
+++ b/inst/extdata/OSD/H/HANLY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively and excessively",
-        "drainage_overview": "somewhat excessively and excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HANOVER.json
+++ b/inst/extdata/OSD/H/HANOVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HANS.json
+++ b/inst/extdata/OSD/H/HANS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HANSKA.json
+++ b/inst/extdata/OSD/H/HANSKA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HAPNEY.json
+++ b/inst/extdata/OSD/H/HAPNEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HAPPYHOLLOW.json
+++ b/inst/extdata/OSD/H/HAPPYHOLLOW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HAPPYISLES.json
+++ b/inst/extdata/OSD/H/HAPPYISLES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well, somewhat poorly",
+        "drainage_overview": "well, moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HARDING.json
+++ b/inst/extdata/OSD/H/HARDING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HARDISTER.json
+++ b/inst/extdata/OSD/H/HARDISTER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HARGREAVE.json
+++ b/inst/extdata/OSD/H/HARGREAVE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HARJO.json
+++ b/inst/extdata/OSD/H/HARJO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/H/HARKERS.json
+++ b/inst/extdata/OSD/H/HARKERS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HARPER.json
+++ b/inst/extdata/OSD/H/HARPER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HARRAH.json
+++ b/inst/extdata/OSD/H/HARRAH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HARRISBURG.json
+++ b/inst/extdata/OSD/H/HARRISBURG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HARRISVILLE.json
+++ b/inst/extdata/OSD/H/HARRISVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HARSTON.json
+++ b/inst/extdata/OSD/H/HARSTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HATTONTOWN.json
+++ b/inst/extdata/OSD/H/HATTONTOWN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HAUGAN.json
+++ b/inst/extdata/OSD/H/HAUGAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HAVERLY.json
+++ b/inst/extdata/OSD/H/HAVERLY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or somewhat poorly",
-        "drainage_overview": "poorly to somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HAVRELON.json
+++ b/inst/extdata/OSD/H/HAVRELON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HAWKEYE.json
+++ b/inst/extdata/OSD/H/HAWKEYE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HAWKSNEST.json
+++ b/inst/extdata/OSD/H/HAWKSNEST.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HAYCAMP.json
+++ b/inst/extdata/OSD/H/HAYCAMP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HAYMARKET.json
+++ b/inst/extdata/OSD/H/HAYMARKET.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HAYMONT.json
+++ b/inst/extdata/OSD/H/HAYMONT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HEADQUARTERS.json
+++ b/inst/extdata/OSD/H/HEADQUARTERS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HEADRICK.json
+++ b/inst/extdata/OSD/H/HEADRICK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/H/HEATON.json
+++ b/inst/extdata/OSD/H/HEATON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HEDMAN.json
+++ b/inst/extdata/OSD/H/HEDMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HEFLIN.json
+++ b/inst/extdata/OSD/H/HEFLIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HEGLAR.json
+++ b/inst/extdata/OSD/H/HEGLAR.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HEIDEN.json
+++ b/inst/extdata/OSD/H/HEIDEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HELDT.json
+++ b/inst/extdata/OSD/H/HELDT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/H/HELMER.json
+++ b/inst/extdata/OSD/H/HELMER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well and moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HENDRICKS.json
+++ b/inst/extdata/OSD/H/HENDRICKS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HENRYSFORK.json
+++ b/inst/extdata/OSD/H/HENRYSFORK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "somewhat poorly to moderately well"
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HEREFORD.json
+++ b/inst/extdata/OSD/H/HEREFORD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HERKIMER.json
+++ b/inst/extdata/OSD/H/HERKIMER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HERMISTON.json
+++ b/inst/extdata/OSD/H/HERMISTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HERNANDEZ.json
+++ b/inst/extdata/OSD/H/HERNANDEZ.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HERRING_CREEK.json
+++ b/inst/extdata/OSD/H/HERRING_CREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HESPERUS.json
+++ b/inst/extdata/OSD/H/HESPERUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HESSEL.json
+++ b/inst/extdata/OSD/H/HESSEL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HETTINGER.json
+++ b/inst/extdata/OSD/H/HETTINGER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HETZ.json
+++ b/inst/extdata/OSD/H/HETZ.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/H/HIBSAW.json
+++ b/inst/extdata/OSD/H/HIBSAW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/H/HICO.json
+++ b/inst/extdata/OSD/H/HICO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HICORIA.json
+++ b/inst/extdata/OSD/H/HICORIA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HIDALGO.json
+++ b/inst/extdata/OSD/H/HIDALGO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HIGHAMS.json
+++ b/inst/extdata/OSD/H/HIGHAMS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HIGHOAKS.json
+++ b/inst/extdata/OSD/H/HIGHOAKS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HIGHPOINT.json
+++ b/inst/extdata/OSD/H/HIGHPOINT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HIKO_SPRINGS.json
+++ b/inst/extdata/OSD/H/HIKO_SPRINGS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HILGRAVE.json
+++ b/inst/extdata/OSD/H/HILGRAVE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HILLERY.json
+++ b/inst/extdata/OSD/H/HILLERY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HILLET.json
+++ b/inst/extdata/OSD/H/HILLET.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HILLFIELD.json
+++ b/inst/extdata/OSD/H/HILLFIELD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HILLGATE.json
+++ b/inst/extdata/OSD/H/HILLGATE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HILLSMERE.json
+++ b/inst/extdata/OSD/H/HILLSMERE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HILMAR.json
+++ b/inst/extdata/OSD/H/HILMAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HILMOE.json
+++ b/inst/extdata/OSD/H/HILMOE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HISLE.json
+++ b/inst/extdata/OSD/H/HISLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOADLY.json
+++ b/inst/extdata/OSD/H/HOADLY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOBACKER.json
+++ b/inst/extdata/OSD/H/HOBACKER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HOBBS.json
+++ b/inst/extdata/OSD/H/HOBBS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HOBOG.json
+++ b/inst/extdata/OSD/H/HOBOG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HOECKERS.json
+++ b/inst/extdata/OSD/H/HOECKERS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOFFLAND.json
+++ b/inst/extdata/OSD/H/HOFFLAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOFFMANVILLE.json
+++ b/inst/extdata/OSD/H/HOFFMANVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HOGG.json
+++ b/inst/extdata/OSD/H/HOGG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOGPEN.json
+++ b/inst/extdata/OSD/H/HOGPEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively or well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HOH.json
+++ b/inst/extdata/OSD/H/HOH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
-        "drainage_overview": "moderately well or well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOLLIS.json
+++ b/inst/extdata/OSD/H/HOLLIS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOLLY.json
+++ b/inst/extdata/OSD/H/HOLLY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOLMDEL.json
+++ b/inst/extdata/OSD/H/HOLMDEL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": "moderately well"
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOLOKUKFAMILY.json
+++ b/inst/extdata/OSD/H/HOLOKUKFAMILY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOLOPAW.json
+++ b/inst/extdata/OSD/H/HOLOPAW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOLSINE.json
+++ b/inst/extdata/OSD/H/HOLSINE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HOLTLE.json
+++ b/inst/extdata/OSD/H/HOLTLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HOLYOKE.json
+++ b/inst/extdata/OSD/H/HOLYOKE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOMESTAKE.json
+++ b/inst/extdata/OSD/H/HOMESTAKE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HOMME.json
+++ b/inst/extdata/OSD/H/HOMME.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HONDALE.json
+++ b/inst/extdata/OSD/H/HONDALE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOOD.json
+++ b/inst/extdata/OSD/H/HOOD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HOOPER.json
+++ b/inst/extdata/OSD/H/HOOPER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOPEVAL.json
+++ b/inst/extdata/OSD/H/HOPEVAL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOPKINS.json
+++ b/inst/extdata/OSD/H/HOPKINS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HOPLEY.json
+++ b/inst/extdata/OSD/H/HOPLEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HORNITOS.json
+++ b/inst/extdata/OSD/H/HORNITOS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively to well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HORROCKS.json
+++ b/inst/extdata/OSD/H/HORROCKS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HOSKIN.json
+++ b/inst/extdata/OSD/H/HOSKIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HOSSICK.json
+++ b/inst/extdata/OSD/H/HOSSICK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HOUSTON_BLACK.json
+++ b/inst/extdata/OSD/H/HOUSTON_BLACK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/H/HOWARD.json
+++ b/inst/extdata/OSD/H/HOWARD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HUB.json
+++ b/inst/extdata/OSD/H/HUB.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HUBBARD.json
+++ b/inst/extdata/OSD/H/HUBBARD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively",
-        "drainage_overview": "excessively and well"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HUBTALF.json
+++ b/inst/extdata/OSD/H/HUBTALF.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/H/HUERHUERO.json
+++ b/inst/extdata/OSD/H/HUERHUERO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or well",
+        "drainage": "well, moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/H/HUFFINE.json
+++ b/inst/extdata/OSD/H/HUFFINE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HULLIGAN.json
+++ b/inst/extdata/OSD/H/HULLIGAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HULLS.json
+++ b/inst/extdata/OSD/H/HULLS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HUMBARGER.json
+++ b/inst/extdata/OSD/H/HUMBARGER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HUMBARSPRINGS.json
+++ b/inst/extdata/OSD/H/HUMBARSPRINGS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HUN.json
+++ b/inst/extdata/OSD/H/HUN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HUNTIMER.json
+++ b/inst/extdata/OSD/H/HUNTIMER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HUPP.json
+++ b/inst/extdata/OSD/H/HUPP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HURLEY.json
+++ b/inst/extdata/OSD/H/HURLEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HUSCHER.json
+++ b/inst/extdata/OSD/H/HUSCHER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HUSE.json
+++ b/inst/extdata/OSD/H/HUSE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HUSKA.json
+++ b/inst/extdata/OSD/H/HUSKA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/H/HUSSA.json
+++ b/inst/extdata/OSD/H/HUSSA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HUTSON.json
+++ b/inst/extdata/OSD/H/HUTSON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HYDRO.json
+++ b/inst/extdata/OSD/H/HYDRO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/H/HYER.json
+++ b/inst/extdata/OSD/H/HYER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/H/HYSHAM.json
+++ b/inst/extdata/OSD/H/HYSHAM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/H/HYSOOP.json
+++ b/inst/extdata/OSD/H/HYSOOP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/I/IHOPE.json
+++ b/inst/extdata/OSD/I/IHOPE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/I/ILIFF.json
+++ b/inst/extdata/OSD/I/ILIFF.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/IMMOKALEE.json
+++ b/inst/extdata/OSD/I/IMMOKALEE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/IMPERIAL.json
+++ b/inst/extdata/OSD/I/IMPERIAL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/I/INDART.json
+++ b/inst/extdata/OSD/I/INDART.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/I/INDIAN_RIVER.json
+++ b/inst/extdata/OSD/I/INDIAN_RIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/INDIO.json
+++ b/inst/extdata/OSD/I/INDIO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/INDUS.json
+++ b/inst/extdata/OSD/I/INDUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and somewhat poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/INEZ.json
+++ b/inst/extdata/OSD/I/INEZ.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/I/INGLEWOOD.json
+++ b/inst/extdata/OSD/I/INGLEWOOD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/I/INKSTER.json
+++ b/inst/extdata/OSD/I/INKSTER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/IPHIL.json
+++ b/inst/extdata/OSD/I/IPHIL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/I/IRAK.json
+++ b/inst/extdata/OSD/I/IRAK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/IRION.json
+++ b/inst/extdata/OSD/I/IRION.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/I/IROCK.json
+++ b/inst/extdata/OSD/I/IROCK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/I/IRONAGE.json
+++ b/inst/extdata/OSD/I/IRONAGE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/I/IRON_MOUNTAIN.json
+++ b/inst/extdata/OSD/I/IRON_MOUNTAIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/IRWIN.json
+++ b/inst/extdata/OSD/I/IRWIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/I/ISABELLA.json
+++ b/inst/extdata/OSD/I/ISABELLA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/I/ISAN.json
+++ b/inst/extdata/OSD/I/ISAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/ISANTI.json
+++ b/inst/extdata/OSD/I/ISANTI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/ISLES.json
+++ b/inst/extdata/OSD/I/ISLES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/ISMAILOF.json
+++ b/inst/extdata/OSD/I/ISMAILOF.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "moderately well and well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/ISOM.json
+++ b/inst/extdata/OSD/I/ISOM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/I/ITTSANAPPER.json
+++ b/inst/extdata/OSD/I/ITTSANAPPER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/I/IVAN.json
+++ b/inst/extdata/OSD/I/IVAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JABU.json
+++ b/inst/extdata/OSD/J/JABU.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JACAGUAS.json
+++ b/inst/extdata/OSD/J/JACAGUAS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well to excessively"
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JACKALOPE.json
+++ b/inst/extdata/OSD/J/JACKALOPE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JACKLAND.json
+++ b/inst/extdata/OSD/J/JACKLAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JACKMILL.json
+++ b/inst/extdata/OSD/J/JACKMILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JACOB.json
+++ b/inst/extdata/OSD/J/JACOB.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JACOBSVILLE.json
+++ b/inst/extdata/OSD/J/JACOBSVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/J/JACQUITH.json
+++ b/inst/extdata/OSD/J/JACQUITH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/J/JAL.json
+++ b/inst/extdata/OSD/J/JAL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JAMES.json
+++ b/inst/extdata/OSD/J/JAMES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JARBOE.json
+++ b/inst/extdata/OSD/J/JARBOE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/J/JARDAL.json
+++ b/inst/extdata/OSD/J/JARDAL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JARITA.json
+++ b/inst/extdata/OSD/J/JARITA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/J/JAYEM.json
+++ b/inst/extdata/OSD/J/JAYEM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "somewhat excessively, well"
       }
     ]

--- a/inst/extdata/OSD/J/JAYEM.json
+++ b/inst/extdata/OSD/J/JAYEM.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JEDDO.json
+++ b/inst/extdata/OSD/J/JEDDO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JEDEDIAH.json
+++ b/inst/extdata/OSD/J/JEDEDIAH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JEFFERSON.json
+++ b/inst/extdata/OSD/J/JEFFERSON.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JENADA.json
+++ b/inst/extdata/OSD/J/JENADA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JENNESS.json
+++ b/inst/extdata/OSD/J/JENNESS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JERAG.json
+++ b/inst/extdata/OSD/J/JERAG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JERAULD.json
+++ b/inst/extdata/OSD/J/JERAULD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JERU.json
+++ b/inst/extdata/OSD/J/JERU.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JICARILLA.json
+++ b/inst/extdata/OSD/J/JICARILLA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/J/JIGGS.json
+++ b/inst/extdata/OSD/J/JIGGS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/J/JIPPER.json
+++ b/inst/extdata/OSD/J/JIPPER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JODERO.json
+++ b/inst/extdata/OSD/J/JODERO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JOECUT.json
+++ b/inst/extdata/OSD/J/JOECUT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JONATHAN.json
+++ b/inst/extdata/OSD/J/JONATHAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat excessively",
-        "drainage_overview": "moderately well to somewhat excessively"
+        "drainage": "somewhat excessively, well, moderately well",
+        "drainage_overview": "somewhat excessively, well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JONESBAY.json
+++ b/inst/extdata/OSD/J/JONESBAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JUBILEE.json
+++ b/inst/extdata/OSD/J/JUBILEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JUDY.json
+++ b/inst/extdata/OSD/J/JUDY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JULES.json
+++ b/inst/extdata/OSD/J/JULES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/J/JUNCTION.json
+++ b/inst/extdata/OSD/J/JUNCTION.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/J/JUPITER.json
+++ b/inst/extdata/OSD/J/JUPITER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KACHEMAK.json
+++ b/inst/extdata/OSD/K/KACHEMAK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KAHNEETA.json
+++ b/inst/extdata/OSD/K/KAHNEETA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KALMARVILLE.json
+++ b/inst/extdata/OSD/K/KALMARVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KAMACK.json
+++ b/inst/extdata/OSD/K/KAMACK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KANIKSU.json
+++ b/inst/extdata/OSD/K/KANIKSU.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KANLEE.json
+++ b/inst/extdata/OSD/K/KANLEE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KANZA.json
+++ b/inst/extdata/OSD/K/KANZA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and somewhat poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KARRO.json
+++ b/inst/extdata/OSD/K/KARRO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KARS.json
+++ b/inst/extdata/OSD/K/KARS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KARTA.json
+++ b/inst/extdata/OSD/K/KARTA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KATHER.json
+++ b/inst/extdata/OSD/K/KATHER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/K/KATO.json
+++ b/inst/extdata/OSD/K/KATO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KATY.json
+++ b/inst/extdata/OSD/K/KATY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/K/KAUDER.json
+++ b/inst/extdata/OSD/K/KAUDER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": ""
+        "drainage_overview": "moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KAYO.json
+++ b/inst/extdata/OSD/K/KAYO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KEDRON.json
+++ b/inst/extdata/OSD/K/KEDRON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/K/KEELDAR.json
+++ b/inst/extdata/OSD/K/KEELDAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KEELINE.json
+++ b/inst/extdata/OSD/K/KEELINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KEETER.json
+++ b/inst/extdata/OSD/K/KEETER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KEMMERER.json
+++ b/inst/extdata/OSD/K/KEMMERER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KENAI.json
+++ b/inst/extdata/OSD/K/KENAI.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KENALDUMA.json
+++ b/inst/extdata/OSD/K/KENALDUMA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KENNER.json
+++ b/inst/extdata/OSD/K/KENNER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/K/KENSPUR.json
+++ b/inst/extdata/OSD/K/KENSPUR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KERBER.json
+++ b/inst/extdata/OSD/K/KERBER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KERSICK.json
+++ b/inst/extdata/OSD/K/KERSICK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KESSLER.json
+++ b/inst/extdata/OSD/K/KESSLER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KESTNER.json
+++ b/inst/extdata/OSD/K/KESTNER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KETTLE.json
+++ b/inst/extdata/OSD/K/KETTLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KETTNER.json
+++ b/inst/extdata/OSD/K/KETTNER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KEYA.json
+++ b/inst/extdata/OSD/K/KEYA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KEYES.json
+++ b/inst/extdata/OSD/K/KEYES.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well and moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KIDAZQENI.json
+++ b/inst/extdata/OSD/K/KIDAZQENI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
-        "drainage_overview": "moderately well or well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KIDD.json
+++ b/inst/extdata/OSD/K/KIDD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "excessively",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/K/KIDMAN.json
+++ b/inst/extdata/OSD/K/KIDMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KILCHIS.json
+++ b/inst/extdata/OSD/K/KILCHIS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or excessively",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KILLDUFF.json
+++ b/inst/extdata/OSD/K/KILLDUFF.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KIM.json
+++ b/inst/extdata/OSD/K/KIM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KINESAVA.json
+++ b/inst/extdata/OSD/K/KINESAVA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/K/KINKEAD.json
+++ b/inst/extdata/OSD/K/KINKEAD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/K/KINROSS.json
+++ b/inst/extdata/OSD/K/KINROSS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KINSEYRIDGE.json
+++ b/inst/extdata/OSD/K/KINSEYRIDGE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KIPER.json
+++ b/inst/extdata/OSD/K/KIPER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KIPPEN.json
+++ b/inst/extdata/OSD/K/KIPPEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/K/KIPSON.json
+++ b/inst/extdata/OSD/K/KIPSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/K/KIRBYVILLE.json
+++ b/inst/extdata/OSD/K/KIRBYVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KIRKENDALL.json
+++ b/inst/extdata/OSD/K/KIRKENDALL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KIRKHAM.json
+++ b/inst/extdata/OSD/K/KIRKHAM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KIRO.json
+++ b/inst/extdata/OSD/K/KIRO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/K/KIWANIS.json
+++ b/inst/extdata/OSD/K/KIWANIS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KLADNICK.json
+++ b/inst/extdata/OSD/K/KLADNICK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KLANELNEECHENA.json
+++ b/inst/extdata/OSD/K/KLANELNEECHENA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly to poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KLASI.json
+++ b/inst/extdata/OSD/K/KLASI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KLAWASI.json
+++ b/inst/extdata/OSD/K/KLAWASI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KLOOTCH.json
+++ b/inst/extdata/OSD/K/KLOOTCH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KLUTCH.json
+++ b/inst/extdata/OSD/K/KLUTCH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KLUTE.json
+++ b/inst/extdata/OSD/K/KLUTE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KNEERIDGE.json
+++ b/inst/extdata/OSD/K/KNEERIDGE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KNICKERBOCKER.json
+++ b/inst/extdata/OSD/K/KNICKERBOCKER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well and somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KNOBBY.json
+++ b/inst/extdata/OSD/K/KNOBBY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
-        "drainage_overview": "well and somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KNOB_LOCK.json
+++ b/inst/extdata/OSD/K/KNOB_LOCK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KNULL.json
+++ b/inst/extdata/OSD/K/KNULL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/K/KOBEL.json
+++ b/inst/extdata/OSD/K/KOBEL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KOGISH.json
+++ b/inst/extdata/OSD/K/KOGISH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KOLLS.json
+++ b/inst/extdata/OSD/K/KOLLS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KOLOB.json
+++ b/inst/extdata/OSD/K/KOLOB.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KONZA.json
+++ b/inst/extdata/OSD/K/KONZA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/K/KRATKA.json
+++ b/inst/extdata/OSD/K/KRATKA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KRUM.json
+++ b/inst/extdata/OSD/K/KRUM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KUCERA.json
+++ b/inst/extdata/OSD/K/KUCERA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/K/KULANI.json
+++ b/inst/extdata/OSD/K/KULANI.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KUNAYOSH.json
+++ b/inst/extdata/OSD/K/KUNAYOSH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/K/KUSLINA.json
+++ b/inst/extdata/OSD/K/KUSLINA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KUSLINAD.json
+++ b/inst/extdata/OSD/K/KUSLINAD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KUTCH.json
+++ b/inst/extdata/OSD/K/KUTCH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/K/KUY.json
+++ b/inst/extdata/OSD/K/KUY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/K/KYGER.json
+++ b/inst/extdata/OSD/K/KYGER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/L/LABETTE.json
+++ b/inst/extdata/OSD/L/LABETTE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LACKSTOWN.json
+++ b/inst/extdata/OSD/L/LACKSTOWN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LACOTA.json
+++ b/inst/extdata/OSD/L/LACOTA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LADDERLAKE.json
+++ b/inst/extdata/OSD/L/LADDERLAKE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LADYSMITH.json
+++ b/inst/extdata/OSD/L/LADYSMITH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/L/LAIRDSVILLE.json
+++ b/inst/extdata/OSD/L/LAIRDSVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
-        "drainage_overview": "moderately well to well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LAKEMONT.json
+++ b/inst/extdata/OSD/L/LAKEMONT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LAKETWIN.json
+++ b/inst/extdata/OSD/L/LAKETWIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LAKEVIEW.json
+++ b/inst/extdata/OSD/L/LAKEVIEW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LALLIE.json
+++ b/inst/extdata/OSD/L/LALLIE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LAMARSH.json
+++ b/inst/extdata/OSD/L/LAMARSH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LAMBERT.json
+++ b/inst/extdata/OSD/L/LAMBERT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LAMOURE.json
+++ b/inst/extdata/OSD/L/LAMOURE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LAMSON.json
+++ b/inst/extdata/OSD/L/LAMSON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LANCASTER.json
+++ b/inst/extdata/OSD/L/LANCASTER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LANE.json
+++ b/inst/extdata/OSD/L/LANE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LANEY.json
+++ b/inst/extdata/OSD/L/LANEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LANG.json
+++ b/inst/extdata/OSD/L/LANG.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat poorly",
-        "drainage_overview": "poorly to somewhat poorly"
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LANIGER.json
+++ b/inst/extdata/OSD/L/LANIGER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LANKTREE.json
+++ b/inst/extdata/OSD/L/LANKTREE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LANSDOWNE.json
+++ b/inst/extdata/OSD/L/LANSDOWNE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LANTON.json
+++ b/inst/extdata/OSD/L/LANTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LARKSON.json
+++ b/inst/extdata/OSD/L/LARKSON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LARSON.json
+++ b/inst/extdata/OSD/L/LARSON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LASSEL.json
+++ b/inst/extdata/OSD/L/LASSEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LAS_ANIMAS.json
+++ b/inst/extdata/OSD/L/LAS_ANIMAS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LAS_FLORES.json
+++ b/inst/extdata/OSD/L/LAS_FLORES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LATENE.json
+++ b/inst/extdata/OSD/L/LATENE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LATOM.json
+++ b/inst/extdata/OSD/L/LATOM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LAUGHLIN.json
+++ b/inst/extdata/OSD/L/LAUGHLIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LAVELDO.json
+++ b/inst/extdata/OSD/L/LAVELDO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "moderately well",
+        "drainage_overview": "moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LAVINA.json
+++ b/inst/extdata/OSD/L/LAVINA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LAWARD.json
+++ b/inst/extdata/OSD/L/LAWARD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/L/LAWET.json
+++ b/inst/extdata/OSD/L/LAWET.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LAYTON.json
+++ b/inst/extdata/OSD/L/LAYTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LEBEC.json
+++ b/inst/extdata/OSD/L/LEBEC.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LEBSACK.json
+++ b/inst/extdata/OSD/L/LEBSACK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/L/LEDMOUNT.json
+++ b/inst/extdata/OSD/L/LEDMOUNT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LEEDS.json
+++ b/inst/extdata/OSD/L/LEEDS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LEETON.json
+++ b/inst/extdata/OSD/L/LEETON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LEETONIA.json
+++ b/inst/extdata/OSD/L/LEETONIA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LEGAULT.json
+++ b/inst/extdata/OSD/L/LEGAULT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LEHEW.json
+++ b/inst/extdata/OSD/L/LEHEW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LEHIGH.json
+++ b/inst/extdata/OSD/L/LEHIGH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LELAND.json
+++ b/inst/extdata/OSD/L/LELAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LEMCO.json
+++ b/inst/extdata/OSD/L/LEMCO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LEMERT.json
+++ b/inst/extdata/OSD/L/LEMERT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LEMOND.json
+++ b/inst/extdata/OSD/L/LEMOND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LENAWEE.json
+++ b/inst/extdata/OSD/L/LENAWEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LENZ.json
+++ b/inst/extdata/OSD/L/LENZ.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LEON.json
+++ b/inst/extdata/OSD/L/LEON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LEONARDO.json
+++ b/inst/extdata/OSD/L/LEONARDO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LERCH.json
+++ b/inst/extdata/OSD/L/LERCH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LESLIE.json
+++ b/inst/extdata/OSD/L/LESLIE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
-        "drainage_overview": "somewhat poorly and poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LETCHER.json
+++ b/inst/extdata/OSD/L/LETCHER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or moderately well",
-        "drainage_overview": "somewhat poorly or moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LEVASY.json
+++ b/inst/extdata/OSD/L/LEVASY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LEWISVILLE.json
+++ b/inst/extdata/OSD/L/LEWISVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LIGNUM.json
+++ b/inst/extdata/OSD/L/LIGNUM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LIHEN.json
+++ b/inst/extdata/OSD/L/LIHEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively or well",
-        "drainage_overview": "somewhat excessively or well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LINGANORE.json
+++ b/inst/extdata/OSD/L/LINGANORE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LINNET.json
+++ b/inst/extdata/OSD/L/LINNET.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LIPAN.json
+++ b/inst/extdata/OSD/L/LIPAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LISCO.json
+++ b/inst/extdata/OSD/L/LISCO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LITHGOW.json
+++ b/inst/extdata/OSD/L/LITHGOW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LITIMBER.json
+++ b/inst/extdata/OSD/L/LITIMBER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LITTLEWATER.json
+++ b/inst/extdata/OSD/L/LITTLEWATER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LIVENGOOD.json
+++ b/inst/extdata/OSD/L/LIVENGOOD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LIZA.json
+++ b/inst/extdata/OSD/L/LIZA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LIZDALE.json
+++ b/inst/extdata/OSD/L/LIZDALE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/L/LIZE.json
+++ b/inst/extdata/OSD/L/LIZE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LODAR.json
+++ b/inst/extdata/OSD/L/LODAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LODGEPOLE.json
+++ b/inst/extdata/OSD/L/LODGEPOLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/L/LOGAN.json
+++ b/inst/extdata/OSD/L/LOGAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/L/LOGDELL.json
+++ b/inst/extdata/OSD/L/LOGDELL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LOGY.json
+++ b/inst/extdata/OSD/L/LOGY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well and somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LOHLER.json
+++ b/inst/extdata/OSD/L/LOHLER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LOLALITA.json
+++ b/inst/extdata/OSD/L/LOLALITA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LONE.json
+++ b/inst/extdata/OSD/L/LONE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LONETREE.json
+++ b/inst/extdata/OSD/L/LONETREE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LONE_ROCK.json
+++ b/inst/extdata/OSD/L/LONE_ROCK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LONGDRIVE.json
+++ b/inst/extdata/OSD/L/LONGDRIVE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LONGPOINT.json
+++ b/inst/extdata/OSD/L/LONGPOINT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LONTI.json
+++ b/inst/extdata/OSD/L/LONTI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LORACK.json
+++ b/inst/extdata/OSD/L/LORACK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LOSTBEAR.json
+++ b/inst/extdata/OSD/L/LOSTBEAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/L/LOSTFORK.json
+++ b/inst/extdata/OSD/L/LOSTFORK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LOSTINE.json
+++ b/inst/extdata/OSD/L/LOSTINE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LOS_GATOS.json
+++ b/inst/extdata/OSD/L/LOS_GATOS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LOTT.json
+++ b/inst/extdata/OSD/L/LOTT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LOTUS.json
+++ b/inst/extdata/OSD/L/LOTUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LOUISBURG.json
+++ b/inst/extdata/OSD/L/LOUISBURG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LOUP.json
+++ b/inst/extdata/OSD/L/LOUP.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "very poorly",
-        "drainage_overview": "poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LOUP.json
+++ b/inst/extdata/OSD/L/LOUP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly, very poorly"
       }
     ]

--- a/inst/extdata/OSD/L/LOUPENCE.json
+++ b/inst/extdata/OSD/L/LOUPENCE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LOUSECREEK.json
+++ b/inst/extdata/OSD/L/LOUSECREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LOVEJOY.json
+++ b/inst/extdata/OSD/L/LOVEJOY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LOWE.json
+++ b/inst/extdata/OSD/L/LOWE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/L/LUCE.json
+++ b/inst/extdata/OSD/L/LUCE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to moderately well",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LUCKNOW.json
+++ b/inst/extdata/OSD/L/LUCKNOW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LUDDEN.json
+++ b/inst/extdata/OSD/L/LUDDEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LUKANIN.json
+++ b/inst/extdata/OSD/L/LUKANIN.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LURA.json
+++ b/inst/extdata/OSD/L/LURA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LUTE.json
+++ b/inst/extdata/OSD/L/LUTE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LUTH.json
+++ b/inst/extdata/OSD/L/LUTH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/L/LUTON.json
+++ b/inst/extdata/OSD/L/LUTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LUXOR.json
+++ b/inst/extdata/OSD/L/LUXOR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/L/LYERLY.json
+++ b/inst/extdata/OSD/L/LYERLY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LYNN_HAVEN.json
+++ b/inst/extdata/OSD/L/LYNN_HAVEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/L/LYONS.json
+++ b/inst/extdata/OSD/L/LYONS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MACHAPUNGA.json
+++ b/inst/extdata/OSD/M/MACHAPUNGA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MACKEN.json
+++ b/inst/extdata/OSD/M/MACKEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MADAWASKA.json
+++ b/inst/extdata/OSD/M/MADAWASKA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MADBUTTES.json
+++ b/inst/extdata/OSD/M/MADBUTTES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MADDOCK.json
+++ b/inst/extdata/OSD/M/MADDOCK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MADERA.json
+++ b/inst/extdata/OSD/M/MADERA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MADUREZ.json
+++ b/inst/extdata/OSD/M/MADUREZ.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MAGGIES.json
+++ b/inst/extdata/OSD/M/MAGGIES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAHALALAND.json
+++ b/inst/extdata/OSD/M/MAHALALAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAHALASVILLE.json
+++ b/inst/extdata/OSD/M/MAHALASVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAINTER.json
+++ b/inst/extdata/OSD/M/MAINTER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAJADA.json
+++ b/inst/extdata/OSD/M/MAJADA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MAKOTI.json
+++ b/inst/extdata/OSD/M/MAKOTI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MALABAR.json
+++ b/inst/extdata/OSD/M/MALABAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MALBIS.json
+++ b/inst/extdata/OSD/M/MALBIS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
-        "drainage_overview": "moderately well or well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MALINTA.json
+++ b/inst/extdata/OSD/M/MALINTA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MALO.json
+++ b/inst/extdata/OSD/M/MALO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MALTESE.json
+++ b/inst/extdata/OSD/M/MALTESE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAMMOTH.json
+++ b/inst/extdata/OSD/M/MAMMOTH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MANADA.json
+++ b/inst/extdata/OSD/M/MANADA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or moderately well",
-        "drainage_overview": "somewhat poorly or moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MANASSAS.json
+++ b/inst/extdata/OSD/M/MANASSAS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MANDEVILLE.json
+++ b/inst/extdata/OSD/M/MANDEVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MANFRED.json
+++ b/inst/extdata/OSD/M/MANFRED.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MANKOMEN.json
+++ b/inst/extdata/OSD/M/MANKOMEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MANLIUS.json
+++ b/inst/extdata/OSD/M/MANLIUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MANOR.json
+++ b/inst/extdata/OSD/M/MANOR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MANSON.json
+++ b/inst/extdata/OSD/M/MANSON.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MANTER.json
+++ b/inst/extdata/OSD/M/MANTER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MANTOLOKING.json
+++ b/inst/extdata/OSD/M/MANTOLOKING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAPLEGROVE.json
+++ b/inst/extdata/OSD/M/MAPLEGROVE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/M/MAQUAM.json
+++ b/inst/extdata/OSD/M/MAQUAM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARATHON.json
+++ b/inst/extdata/OSD/M/MARATHON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARBLEYARD.json
+++ b/inst/extdata/OSD/M/MARBLEYARD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARCUS.json
+++ b/inst/extdata/OSD/M/MARCUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAREAS.json
+++ b/inst/extdata/OSD/M/MAREAS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARGERUM.json
+++ b/inst/extdata/OSD/M/MARGERUM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MARGO.json
+++ b/inst/extdata/OSD/M/MARGO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": ""
+        "drainage_overview": "moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARIOLA.json
+++ b/inst/extdata/OSD/M/MARIOLA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MARIPOSA.json
+++ b/inst/extdata/OSD/M/MARIPOSA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MARISSA.json
+++ b/inst/extdata/OSD/M/MARISSA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARKLEY.json
+++ b/inst/extdata/OSD/M/MARKLEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/M/MARLAKE.json
+++ b/inst/extdata/OSD/M/MARLAKE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/M/MARMOTLAND.json
+++ b/inst/extdata/OSD/M/MARMOTLAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAROSA.json
+++ b/inst/extdata/OSD/M/MAROSA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARSEILLES.json
+++ b/inst/extdata/OSD/M/MARSEILLES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARSHAN.json
+++ b/inst/extdata/OSD/M/MARSHAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARSHBROOK.json
+++ b/inst/extdata/OSD/M/MARSHBROOK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or poorly",
-        "drainage_overview": "somewhat poorly or poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARSHNECK.json
+++ b/inst/extdata/OSD/M/MARSHNECK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARSING.json
+++ b/inst/extdata/OSD/M/MARSING.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MARTINECK.json
+++ b/inst/extdata/OSD/M/MARTINECK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MARTINEZ.json
+++ b/inst/extdata/OSD/M/MARTINEZ.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MARTINSBURG.json
+++ b/inst/extdata/OSD/M/MARTINSBURG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARTY.json
+++ b/inst/extdata/OSD/M/MARTY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MARUMSCO.json
+++ b/inst/extdata/OSD/M/MARUMSCO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MARVIN.json
+++ b/inst/extdata/OSD/M/MARVIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MARYSLAND.json
+++ b/inst/extdata/OSD/M/MARYSLAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAR_NEGRO.json
+++ b/inst/extdata/OSD/M/MAR_NEGRO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MASCOTTE.json
+++ b/inst/extdata/OSD/M/MASCOTTE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MASON.json
+++ b/inst/extdata/OSD/M/MASON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/M/MASSAPOG.json
+++ b/inst/extdata/OSD/M/MASSAPOG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MASSBACH.json
+++ b/inst/extdata/OSD/M/MASSBACH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MASSENA.json
+++ b/inst/extdata/OSD/M/MASSENA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MASTERSON.json
+++ b/inst/extdata/OSD/M/MASTERSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MATHERS.json
+++ b/inst/extdata/OSD/M/MATHERS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MATTAPONI.json
+++ b/inst/extdata/OSD/M/MATTAPONI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAUDE.json
+++ b/inst/extdata/OSD/M/MAUDE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MAUKEY.json
+++ b/inst/extdata/OSD/M/MAUKEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MAUMEE.json
+++ b/inst/extdata/OSD/M/MAUMEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAXCREEK.json
+++ b/inst/extdata/OSD/M/MAXCREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAYBEE.json
+++ b/inst/extdata/OSD/M/MAYBEE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAYER.json
+++ b/inst/extdata/OSD/M/MAYER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MAYHILL.json
+++ b/inst/extdata/OSD/M/MAYHILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MAYO.json
+++ b/inst/extdata/OSD/M/MAYO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MAYSDORF.json
+++ b/inst/extdata/OSD/M/MAYSDORF.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MAZOURKA.json
+++ b/inst/extdata/OSD/M/MAZOURKA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MCBIGGAM.json
+++ b/inst/extdata/OSD/M/MCBIGGAM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MCBRIDE.json
+++ b/inst/extdata/OSD/M/MCBRIDE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MCCAFFERY.json
+++ b/inst/extdata/OSD/M/MCCAFFERY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MCCAMMON.json
+++ b/inst/extdata/OSD/M/MCCAMMON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MCCANN.json
+++ b/inst/extdata/OSD/M/MCCANN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MCCLAVE.json
+++ b/inst/extdata/OSD/M/MCCLAVE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
-        "drainage_overview": "poorly to somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MCCROSKET.json
+++ b/inst/extdata/OSD/M/MCCROSKET.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MCFAIN.json
+++ b/inst/extdata/OSD/M/MCFAIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MCGAFFEY.json
+++ b/inst/extdata/OSD/M/MCGAFFEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MCGEE.json
+++ b/inst/extdata/OSD/M/MCGEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "somewhat poorly or moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MCLENNAN.json
+++ b/inst/extdata/OSD/M/MCLENNAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MCMULLIN.json
+++ b/inst/extdata/OSD/M/MCMULLIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
-        "drainage_overview": "well and somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MCMURDIE.json
+++ b/inst/extdata/OSD/M/MCMURDIE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MCPAUL.json
+++ b/inst/extdata/OSD/M/MCPAUL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MCPHIE.json
+++ b/inst/extdata/OSD/M/MCPHIE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MCQUARRIE.json
+++ b/inst/extdata/OSD/M/MCQUARRIE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MCRAE.json
+++ b/inst/extdata/OSD/M/MCRAE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MCVICKERS.json
+++ b/inst/extdata/OSD/M/MCVICKERS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MEAD.json
+++ b/inst/extdata/OSD/M/MEAD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/M/MEADOWBROOK.json
+++ b/inst/extdata/OSD/M/MEADOWBROOK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MEADOWVILLE.json
+++ b/inst/extdata/OSD/M/MEADOWVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "moderately well to well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MEDBURN.json
+++ b/inst/extdata/OSD/M/MEDBURN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MEEKS.json
+++ b/inst/extdata/OSD/M/MEEKS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MEIKLE.json
+++ b/inst/extdata/OSD/M/MEIKLE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": "poorly and very poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MELAKWA.json
+++ b/inst/extdata/OSD/M/MELAKWA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MELDER.json
+++ b/inst/extdata/OSD/M/MELDER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MELLOR.json
+++ b/inst/extdata/OSD/M/MELLOR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MENAHGA.json
+++ b/inst/extdata/OSD/M/MENAHGA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "excessively",
-        "drainage_overview": "excessively"
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MENDELTNA.json
+++ b/inst/extdata/OSD/M/MENDELTNA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MENDNA.json
+++ b/inst/extdata/OSD/M/MENDNA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MENEFEE.json
+++ b/inst/extdata/OSD/M/MENEFEE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MENTZ.json
+++ b/inst/extdata/OSD/M/MENTZ.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/M/MERDEN.json
+++ b/inst/extdata/OSD/M/MERDEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or somewhat poorly",
-        "drainage_overview": "poorly or somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MESCAL.json
+++ b/inst/extdata/OSD/M/MESCAL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MET.json
+++ b/inst/extdata/OSD/M/MET.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/METEDECONK.json
+++ b/inst/extdata/OSD/M/METEDECONK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MICHELSON.json
+++ b/inst/extdata/OSD/M/MICHELSON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MIDDLEMOOR.json
+++ b/inst/extdata/OSD/M/MIDDLEMOOR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MIDDLERES.json
+++ b/inst/extdata/OSD/M/MIDDLERES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MIKE.json
+++ b/inst/extdata/OSD/M/MIKE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MILFORD.json
+++ b/inst/extdata/OSD/M/MILFORD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MILK.json
+++ b/inst/extdata/OSD/M/MILK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MILLERTON.json
+++ b/inst/extdata/OSD/M/MILLERTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MILLSITE.json
+++ b/inst/extdata/OSD/M/MILLSITE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MILLVILLE.json
+++ b/inst/extdata/OSD/M/MILLVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MILL_HOLLOW.json
+++ b/inst/extdata/OSD/M/MILL_HOLLOW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MINA.json
+++ b/inst/extdata/OSD/M/MINA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MINDEGO.json
+++ b/inst/extdata/OSD/M/MINDEGO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MINERAL_MOUNTAIN.json
+++ b/inst/extdata/OSD/M/MINERAL_MOUNTAIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MINNIECE.json
+++ b/inst/extdata/OSD/M/MINNIECE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and somewhat poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MINNITH.json
+++ b/inst/extdata/OSD/M/MINNITH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MINOCQUA.json
+++ b/inst/extdata/OSD/M/MINOCQUA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MINSTER.json
+++ b/inst/extdata/OSD/M/MINSTER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MINWELLS.json
+++ b/inst/extdata/OSD/M/MINWELLS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MIRANDA.json
+++ b/inst/extdata/OSD/M/MIRANDA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MISENHEIMER.json
+++ b/inst/extdata/OSD/M/MISENHEIMER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/M/MOANO.json
+++ b/inst/extdata/OSD/M/MOANO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MOBRIDGE.json
+++ b/inst/extdata/OSD/M/MOBRIDGE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOCANE.json
+++ b/inst/extdata/OSD/M/MOCANE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/M/MOCKLEY.json
+++ b/inst/extdata/OSD/M/MOCKLEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MODJESKA.json
+++ b/inst/extdata/OSD/M/MODJESKA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOGLIA.json
+++ b/inst/extdata/OSD/M/MOGLIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MOHAGGIN.json
+++ b/inst/extdata/OSD/M/MOHAGGIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MOKELUMNE.json
+++ b/inst/extdata/OSD/M/MOKELUMNE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well or moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOKIAK.json
+++ b/inst/extdata/OSD/M/MOKIAK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MOKO.json
+++ b/inst/extdata/OSD/M/MOKO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MONACAN.json
+++ b/inst/extdata/OSD/M/MONACAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MONAVILLE.json
+++ b/inst/extdata/OSD/M/MONAVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MONDAMIN.json
+++ b/inst/extdata/OSD/M/MONDAMIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MONEE.json
+++ b/inst/extdata/OSD/M/MONEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MONON.json
+++ b/inst/extdata/OSD/M/MONON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MONSERATE.json
+++ b/inst/extdata/OSD/M/MONSERATE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MONTGOMERY.json
+++ b/inst/extdata/OSD/M/MONTGOMERY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MONTOUR.json
+++ b/inst/extdata/OSD/M/MONTOUR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MONTPELLIER.json
+++ b/inst/extdata/OSD/M/MONTPELLIER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MONTSWEET.json
+++ b/inst/extdata/OSD/M/MONTSWEET.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively to well",
-        "drainage_overview": "somewhat excessively to well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOOSE_RIVER.json
+++ b/inst/extdata/OSD/M/MOOSE_RIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOOSILAUKE.json
+++ b/inst/extdata/OSD/M/MOOSILAUKE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and somewhat poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOPANG.json
+++ b/inst/extdata/OSD/M/MOPANG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOREAU.json
+++ b/inst/extdata/OSD/M/MOREAU.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOREGLADE.json
+++ b/inst/extdata/OSD/M/MOREGLADE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOREHEAD.json
+++ b/inst/extdata/OSD/M/MOREHEAD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "somewhat poorly or moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MORET.json
+++ b/inst/extdata/OSD/M/MORET.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MORFITT.json
+++ b/inst/extdata/OSD/M/MORFITT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOROROCK.json
+++ b/inst/extdata/OSD/M/MOROROCK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/M/MORRILL.json
+++ b/inst/extdata/OSD/M/MORRILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MOSHER.json
+++ b/inst/extdata/OSD/M/MOSHER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOTA.json
+++ b/inst/extdata/OSD/M/MOTA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MOUNDPRAIRIE.json
+++ b/inst/extdata/OSD/M/MOUNDPRAIRIE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOUNTAINVILLE.json
+++ b/inst/extdata/OSD/M/MOUNTAINVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MOUNTMED.json
+++ b/inst/extdata/OSD/M/MOUNTMED.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOUNTVIEW.json
+++ b/inst/extdata/OSD/M/MOUNTVIEW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOUNT_HOME.json
+++ b/inst/extdata/OSD/M/MOUNT_HOME.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOUNT_LUCAS.json
+++ b/inst/extdata/OSD/M/MOUNT_LUCAS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MOWER.json
+++ b/inst/extdata/OSD/M/MOWER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MUDDY_CREEK.json
+++ b/inst/extdata/OSD/M/MUDDY_CREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MUDGEDRAW.json
+++ b/inst/extdata/OSD/M/MUDGEDRAW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MUD_SPRINGS.json
+++ b/inst/extdata/OSD/M/MUD_SPRINGS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MUIR.json
+++ b/inst/extdata/OSD/M/MUIR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MUIRKIRK.json
+++ b/inst/extdata/OSD/M/MUIRKIRK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MULLET.json
+++ b/inst/extdata/OSD/M/MULLET.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MUNDOS.json
+++ b/inst/extdata/OSD/M/MUNDOS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MUNJOR.json
+++ b/inst/extdata/OSD/M/MUNJOR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well, moderately well",
         "drainage_overview": "well, moderately well"
       }
     ]

--- a/inst/extdata/OSD/M/MUNJOR.json
+++ b/inst/extdata/OSD/M/MUNJOR.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": "well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MUNUSCONG.json
+++ b/inst/extdata/OSD/M/MUNUSCONG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MURAD.json
+++ b/inst/extdata/OSD/M/MURAD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MURDOCK.json
+++ b/inst/extdata/OSD/M/MURDOCK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/M/MURFREESBORO.json
+++ b/inst/extdata/OSD/M/MURFREESBORO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MURRIETA.json
+++ b/inst/extdata/OSD/M/MURRIETA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/M/MUSCOTAH.json
+++ b/inst/extdata/OSD/M/MUSCOTAH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/M/MUSSEL.json
+++ b/inst/extdata/OSD/M/MUSSEL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MUSSEY.json
+++ b/inst/extdata/OSD/M/MUSSEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MYAKKA.json
+++ b/inst/extdata/OSD/M/MYAKKA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MYERS.json
+++ b/inst/extdata/OSD/M/MYERS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/M/MYSTERY.json
+++ b/inst/extdata/OSD/M/MYSTERY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": ""
+        "drainage_overview": "moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NAGUNT.json
+++ b/inst/extdata/OSD/N/NAGUNT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NAHATCHE.json
+++ b/inst/extdata/OSD/N/NAHATCHE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/N/NAHON.json
+++ b/inst/extdata/OSD/N/NAHON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NAPA.json
+++ b/inst/extdata/OSD/N/NAPA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NAPATREE.json
+++ b/inst/extdata/OSD/N/NAPATREE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NARLON.json
+++ b/inst/extdata/OSD/N/NARLON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/N/NASKEAG.json
+++ b/inst/extdata/OSD/N/NASKEAG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NATURITA.json
+++ b/inst/extdata/OSD/N/NATURITA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/N/NAUKATI.json
+++ b/inst/extdata/OSD/N/NAUKATI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NAUMBURG.json
+++ b/inst/extdata/OSD/N/NAUMBURG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NAYPED.json
+++ b/inst/extdata/OSD/N/NAYPED.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/N/NAZ.json
+++ b/inst/extdata/OSD/N/NAZ.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NEBOPEAK.json
+++ b/inst/extdata/OSD/N/NEBOPEAK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NEESOPAH.json
+++ b/inst/extdata/OSD/N/NEESOPAH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NEHAR.json
+++ b/inst/extdata/OSD/N/NEHAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/N/NEKOMA.json
+++ b/inst/extdata/OSD/N/NEKOMA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NELMAN.json
+++ b/inst/extdata/OSD/N/NELMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/N/NETAWAKA.json
+++ b/inst/extdata/OSD/N/NETAWAKA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
-        "drainage_overview": "well and somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NETTLES.json
+++ b/inst/extdata/OSD/N/NETTLES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NEVU.json
+++ b/inst/extdata/OSD/N/NEVU.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/N/NEWALBIN.json
+++ b/inst/extdata/OSD/N/NEWALBIN.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NEWBERN.json
+++ b/inst/extdata/OSD/N/NEWBERN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively and somewhat excessively",
-        "drainage_overview": "excessively and somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NEWCOMER.json
+++ b/inst/extdata/OSD/N/NEWCOMER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/N/NEWELL.json
+++ b/inst/extdata/OSD/N/NEWELL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/N/NEWFORK.json
+++ b/inst/extdata/OSD/N/NEWFORK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
-        "drainage_overview": "poorly to somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NEWSON.json
+++ b/inst/extdata/OSD/N/NEWSON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NEWTONIA.json
+++ b/inst/extdata/OSD/N/NEWTONIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/N/NEW_CAMBRIA.json
+++ b/inst/extdata/OSD/N/NEW_CAMBRIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/N/NEZ.json
+++ b/inst/extdata/OSD/N/NEZ.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/N/NICODEMUS.json
+++ b/inst/extdata/OSD/N/NICODEMUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well, moderately well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NIHILL.json
+++ b/inst/extdata/OSD/N/NIHILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/N/NIKLASON.json
+++ b/inst/extdata/OSD/N/NIKLASON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NIKOLAI.json
+++ b/inst/extdata/OSD/N/NIKOLAI.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly or somewhat poorly"
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NIKWASI.json
+++ b/inst/extdata/OSD/N/NIKWASI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NILAND.json
+++ b/inst/extdata/OSD/N/NILAND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/N/NIMBRO.json
+++ b/inst/extdata/OSD/N/NIMBRO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NIMERICK.json
+++ b/inst/extdata/OSD/N/NIMERICK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/N/NIMROD.json
+++ b/inst/extdata/OSD/N/NIMROD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/N/NINEKAR.json
+++ b/inst/extdata/OSD/N/NINEKAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NIOBELL.json
+++ b/inst/extdata/OSD/N/NIOBELL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NIPSUM.json
+++ b/inst/extdata/OSD/N/NIPSUM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/N/NISHNA.json
+++ b/inst/extdata/OSD/N/NISHNA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NIWOT.json
+++ b/inst/extdata/OSD/N/NIWOT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
-        "drainage_overview": "somewhat poorly to poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NIZINA.json
+++ b/inst/extdata/OSD/N/NIZINA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively",
-        "drainage_overview": "somewhat excessively or excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NOAGUA.json
+++ b/inst/extdata/OSD/N/NOAGUA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NOHOPE.json
+++ b/inst/extdata/OSD/N/NOHOPE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NOISY.json
+++ b/inst/extdata/OSD/N/NOISY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/N/NOKHU.json
+++ b/inst/extdata/OSD/N/NOKHU.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/N/NOONAN.json
+++ b/inst/extdata/OSD/N/NOONAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NOONKU.json
+++ b/inst/extdata/OSD/N/NOONKU.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "very poorly",
-        "drainage_overview": ""
+        "drainage_overview": "very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NOPAH.json
+++ b/inst/extdata/OSD/N/NOPAH.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NORAD.json
+++ b/inst/extdata/OSD/N/NORAD.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NORCHIP.json
+++ b/inst/extdata/OSD/N/NORCHIP.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NORENE.json
+++ b/inst/extdata/OSD/N/NORENE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NORTE.json
+++ b/inst/extdata/OSD/N/NORTE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NORTHCOTE.json
+++ b/inst/extdata/OSD/N/NORTHCOTE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NORWAY.json
+++ b/inst/extdata/OSD/N/NORWAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NORWAY_FLAT.json
+++ b/inst/extdata/OSD/N/NORWAY_FLAT.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NORWICH.json
+++ b/inst/extdata/OSD/N/NORWICH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NOTOM.json
+++ b/inst/extdata/OSD/N/NOTOM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively or excessively",
-        "drainage_overview": "somewhat excessively to excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NOTUS.json
+++ b/inst/extdata/OSD/N/NOTUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NOWHERE.json
+++ b/inst/extdata/OSD/N/NOWHERE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NOXVILLE.json
+++ b/inst/extdata/OSD/N/NOXVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/N/NOYES.json
+++ b/inst/extdata/OSD/N/NOYES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and somewhat poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/N/NUNICA.json
+++ b/inst/extdata/OSD/N/NUNICA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NUTALL.json
+++ b/inst/extdata/OSD/N/NUTALL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/N/NUTMEG.json
+++ b/inst/extdata/OSD/N/NUTMEG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/N/NUTRIOSO.json
+++ b/inst/extdata/OSD/N/NUTRIOSO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OAKALLA.json
+++ b/inst/extdata/OSD/O/OAKALLA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OAKBORO.json
+++ b/inst/extdata/OSD/O/OAKBORO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OAKDEN.json
+++ b/inst/extdata/OSD/O/OAKDEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OAK_GROVE.json
+++ b/inst/extdata/OSD/O/OAK_GROVE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OBAN.json
+++ b/inst/extdata/OSD/O/OBAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/O/OBERT.json
+++ b/inst/extdata/OSD/O/OBERT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OBRAST.json
+++ b/inst/extdata/OSD/O/OBRAST.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/O/OBRAY.json
+++ b/inst/extdata/OSD/O/OBRAY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/O/OCCOQUAN.json
+++ b/inst/extdata/OSD/O/OCCOQUAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OCHILTREE.json
+++ b/inst/extdata/OSD/O/OCHILTREE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/O/OCQUEOC.json
+++ b/inst/extdata/OSD/O/OCQUEOC.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/ODO.json
+++ b/inst/extdata/OSD/O/ODO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OGLALA.json
+++ b/inst/extdata/OSD/O/OGLALA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OHMAN.json
+++ b/inst/extdata/OSD/O/OHMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OJINAGA.json
+++ b/inst/extdata/OSD/O/OJINAGA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OKEE.json
+++ b/inst/extdata/OSD/O/OKEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OLDALE.json
+++ b/inst/extdata/OSD/O/OLDALE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OLDSMAR.json
+++ b/inst/extdata/OSD/O/OLDSMAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OLDWOMAN.json
+++ b/inst/extdata/OSD/O/OLDWOMAN.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OLIVENHAIN.json
+++ b/inst/extdata/OSD/O/OLIVENHAIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/O/OLSON.json
+++ b/inst/extdata/OSD/O/OLSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OMIO.json
+++ b/inst/extdata/OSD/O/OMIO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OMSTOTT.json
+++ b/inst/extdata/OSD/O/OMSTOTT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/O/ONAWAY.json
+++ b/inst/extdata/OSD/O/ONAWAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/ONIONPIE.json
+++ b/inst/extdata/OSD/O/ONIONPIE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/O/ONITA.json
+++ b/inst/extdata/OSD/O/ONITA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/ONOTA.json
+++ b/inst/extdata/OSD/O/ONOTA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/ONSLOW.json
+++ b/inst/extdata/OSD/O/ONSLOW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/ONTKO.json
+++ b/inst/extdata/OSD/O/ONTKO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/ONYX.json
+++ b/inst/extdata/OSD/O/ONYX.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OPOLIS.json
+++ b/inst/extdata/OSD/O/OPOLIS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/O/OQUAGA.json
+++ b/inst/extdata/OSD/O/OQUAGA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/ORACLEOAK.json
+++ b/inst/extdata/OSD/O/ORACLEOAK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat excessively",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/ORANGE.json
+++ b/inst/extdata/OSD/O/ORANGE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/ORDNANCE.json
+++ b/inst/extdata/OSD/O/ORDNANCE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/ORIO.json
+++ b/inst/extdata/OSD/O/ORIO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/O/ORIZABA.json
+++ b/inst/extdata/OSD/O/ORIZABA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/O/ORPHA.json
+++ b/inst/extdata/OSD/O/ORPHA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or excessively",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "excessively"
       }
     ]

--- a/inst/extdata/OSD/O/ORSA.json
+++ b/inst/extdata/OSD/O/ORSA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/ORUPA.json
+++ b/inst/extdata/OSD/O/ORUPA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OSKAWALIKFAMILY.json
+++ b/inst/extdata/OSD/O/OSKAWALIKFAMILY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly to poorly",
-        "drainage_overview": "very poorly to poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OSMUND.json
+++ b/inst/extdata/OSD/O/OSMUND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/O/OSOTE.json
+++ b/inst/extdata/OSD/O/OSOTE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OSTIN.json
+++ b/inst/extdata/OSD/O/OSTIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OTERO.json
+++ b/inst/extdata/OSD/O/OTERO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OTOE.json
+++ b/inst/extdata/OSD/O/OTOE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/O/OTTER.json
+++ b/inst/extdata/OSD/O/OTTER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/O/OURAY.json
+++ b/inst/extdata/OSD/O/OURAY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OVERBOARD.json
+++ b/inst/extdata/OSD/O/OVERBOARD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OVERLAND.json
+++ b/inst/extdata/OSD/O/OVERLAND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OVERLY.json
+++ b/inst/extdata/OSD/O/OVERLY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/O/OWYHEE.json
+++ b/inst/extdata/OSD/O/OWYHEE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/O/OYSTERLAKE.json
+++ b/inst/extdata/OSD/O/OYSTERLAKE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PACHECO.json
+++ b/inst/extdata/OSD/P/PACHECO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or somewhat poorly",
-        "drainage_overview": "poorly or somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PACKWOOD.json
+++ b/inst/extdata/OSD/P/PACKWOOD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PACTOLUS.json
+++ b/inst/extdata/OSD/P/PACTOLUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PADDYKNOB.json
+++ b/inst/extdata/OSD/P/PADDYKNOB.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PADONIA.json
+++ b/inst/extdata/OSD/P/PADONIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PAGOSA.json
+++ b/inst/extdata/OSD/P/PAGOSA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PAHRANAGAT.json
+++ b/inst/extdata/OSD/P/PAHRANAGAT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PAICE.json
+++ b/inst/extdata/OSD/P/PAICE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PALATINE.json
+++ b/inst/extdata/OSD/P/PALATINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PALMA.json
+++ b/inst/extdata/OSD/P/PALMA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat excessively",
-        "drainage_overview": "well and somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PALMER_CANYON.json
+++ b/inst/extdata/OSD/P/PALMER_CANYON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PALMYRA.json
+++ b/inst/extdata/OSD/P/PALMYRA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PALM_BEACH.json
+++ b/inst/extdata/OSD/P/PALM_BEACH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PALOMAS.json
+++ b/inst/extdata/OSD/P/PALOMAS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PALOMINO.json
+++ b/inst/extdata/OSD/P/PALOMINO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PANDO.json
+++ b/inst/extdata/OSD/P/PANDO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PANDOAH.json
+++ b/inst/extdata/OSD/P/PANDOAH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PANIN.json
+++ b/inst/extdata/OSD/P/PANIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PANSEY.json
+++ b/inst/extdata/OSD/P/PANSEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PANTON.json
+++ b/inst/extdata/OSD/P/PANTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PAOLI.json
+++ b/inst/extdata/OSD/P/PAOLI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PARENT.json
+++ b/inst/extdata/OSD/P/PARENT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PARKALLEY.json
+++ b/inst/extdata/OSD/P/PARKALLEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PARKFIELD.json
+++ b/inst/extdata/OSD/P/PARKFIELD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PARKHILL.json
+++ b/inst/extdata/OSD/P/PARKHILL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PARLEYS.json
+++ b/inst/extdata/OSD/P/PARLEYS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PARNELL.json
+++ b/inst/extdata/OSD/P/PARNELL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PAROHTOG.json
+++ b/inst/extdata/OSD/P/PAROHTOG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PARRISH.json
+++ b/inst/extdata/OSD/P/PARRISH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PARSHALL.json
+++ b/inst/extdata/OSD/P/PARSHALL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PARTOFSHIKOF.json
+++ b/inst/extdata/OSD/P/PARTOFSHIKOF.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PARTOV.json
+++ b/inst/extdata/OSD/P/PARTOV.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PARTRI.json
+++ b/inst/extdata/OSD/P/PARTRI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PASCACK.json
+++ b/inst/extdata/OSD/P/PASCACK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PASCO.json
+++ b/inst/extdata/OSD/P/PASCO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PASQUETTI.json
+++ b/inst/extdata/OSD/P/PASQUETTI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PASS_CANYON.json
+++ b/inst/extdata/OSD/P/PASS_CANYON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PASTURECREEK.json
+++ b/inst/extdata/OSD/P/PASTURECREEK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PASTURE_POINT.json
+++ b/inst/extdata/OSD/P/PASTURE_POINT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PATE.json
+++ b/inst/extdata/OSD/P/PATE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PATILO.json
+++ b/inst/extdata/OSD/P/PATILO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PATRICK.json
+++ b/inst/extdata/OSD/P/PATRICK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PATTON.json
+++ b/inst/extdata/OSD/P/PATTON.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PAULSON.json
+++ b/inst/extdata/OSD/P/PAULSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PAVANT.json
+++ b/inst/extdata/OSD/P/PAVANT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PAVILLION.json
+++ b/inst/extdata/OSD/P/PAVILLION.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PAXICO.json
+++ b/inst/extdata/OSD/P/PAXICO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/P/PAYRAISE.json
+++ b/inst/extdata/OSD/P/PAYRAISE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PAYSON.json
+++ b/inst/extdata/OSD/P/PAYSON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PEAKED.json
+++ b/inst/extdata/OSD/P/PEAKED.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "moderately well",
+        "drainage_overview": "moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PEAVY.json
+++ b/inst/extdata/OSD/P/PEAVY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PEDLEFORD.json
+++ b/inst/extdata/OSD/P/PEDLEFORD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PEDRICK.json
+++ b/inst/extdata/OSD/P/PEDRICK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PEMBERTON.json
+++ b/inst/extdata/OSD/P/PEMBERTON.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": ""
+        "drainage_overview": "moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PENDANT.json
+++ b/inst/extdata/OSD/P/PENDANT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PENDER.json
+++ b/inst/extdata/OSD/P/PENDER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PENDERGRASS.json
+++ b/inst/extdata/OSD/P/PENDERGRASS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PENNSUCO.json
+++ b/inst/extdata/OSD/P/PENNSUCO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PENROSE.json
+++ b/inst/extdata/OSD/P/PENROSE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": "well and somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PERCY.json
+++ b/inst/extdata/OSD/P/PERCY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PERITSA.json
+++ b/inst/extdata/OSD/P/PERITSA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PERSHING.json
+++ b/inst/extdata/OSD/P/PERSHING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PESMORE.json
+++ b/inst/extdata/OSD/P/PESMORE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PETROF.json
+++ b/inst/extdata/OSD/P/PETROF.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PETROLIA.json
+++ b/inst/extdata/OSD/P/PETROLIA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PETZEL.json
+++ b/inst/extdata/OSD/P/PETZEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PHAGE.json
+++ b/inst/extdata/OSD/P/PHAGE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PHARO.json
+++ b/inst/extdata/OSD/P/PHARO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/P/PHILDER.json
+++ b/inst/extdata/OSD/P/PHILDER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PHOEBE.json
+++ b/inst/extdata/OSD/P/PHOEBE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PICAYUNE.json
+++ b/inst/extdata/OSD/P/PICAYUNE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PIEDRABLANCA.json
+++ b/inst/extdata/OSD/P/PIEDRABLANCA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
+        "drainage": "well, moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/P/PILCHUCK.json
+++ b/inst/extdata/OSD/P/PILCHUCK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat excessively",
-        "drainage_overview": "excessively"
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PILEDRIVER.json
+++ b/inst/extdata/OSD/P/PILEDRIVER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat poorly",
-        "drainage_overview": ""
+        "drainage_overview": "somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PILLARS.json
+++ b/inst/extdata/OSD/P/PILLARS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PILOTPEAK.json
+++ b/inst/extdata/OSD/P/PILOTPEAK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PINAL.json
+++ b/inst/extdata/OSD/P/PINAL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PINCKNEY.json
+++ b/inst/extdata/OSD/P/PINCKNEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PINCONNING.json
+++ b/inst/extdata/OSD/P/PINCONNING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PINEGAP.json
+++ b/inst/extdata/OSD/P/PINEGAP.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PINEGUEST.json
+++ b/inst/extdata/OSD/P/PINEGUEST.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PINERIDGE.json
+++ b/inst/extdata/OSD/P/PINERIDGE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or somewhat poorly",
-        "drainage_overview": "somewhat poorly or poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PINNACLE.json
+++ b/inst/extdata/OSD/P/PINNACLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PINNACLES.json
+++ b/inst/extdata/OSD/P/PINNACLES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PINUSCREEK.json
+++ b/inst/extdata/OSD/P/PINUSCREEK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PIOPOLIS.json
+++ b/inst/extdata/OSD/P/PIOPOLIS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PISHAGQUA.json
+++ b/inst/extdata/OSD/P/PISHAGQUA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PIUTESPRING.json
+++ b/inst/extdata/OSD/P/PIUTESPRING.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PLACENTIA.json
+++ b/inst/extdata/OSD/P/PLACENTIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PLATDON.json
+++ b/inst/extdata/OSD/P/PLATDON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PLEASANT.json
+++ b/inst/extdata/OSD/P/PLEASANT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PLEASANTON.json
+++ b/inst/extdata/OSD/P/PLEASANTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PLEASANT_GROVE.json
+++ b/inst/extdata/OSD/P/PLEASANT_GROVE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PLUMASANO.json
+++ b/inst/extdata/OSD/P/PLUMASANO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PLUMMER.json
+++ b/inst/extdata/OSD/P/PLUMMER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/POARCH.json
+++ b/inst/extdata/OSD/P/POARCH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PODEN.json
+++ b/inst/extdata/OSD/P/PODEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/POGUEPOINT.json
+++ b/inst/extdata/OSD/P/POGUEPOINT.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/POHOCCO.json
+++ b/inst/extdata/OSD/P/POHOCCO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/POISONCREEK.json
+++ b/inst/extdata/OSD/P/POISONCREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/POLATIS.json
+++ b/inst/extdata/OSD/P/POLATIS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/POLOVINA.json
+++ b/inst/extdata/OSD/P/POLOVINA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/POMELLO.json
+++ b/inst/extdata/OSD/P/POMELLO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/POMONA.json
+++ b/inst/extdata/OSD/P/POMONA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly to poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/POMPANO.json
+++ b/inst/extdata/OSD/P/POMPANO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly to poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/POMPTON.json
+++ b/inst/extdata/OSD/P/POMPTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/POND.json
+++ b/inst/extdata/OSD/P/POND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to moderately well",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/POORMA.json
+++ b/inst/extdata/OSD/P/POORMA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/POOSE.json
+++ b/inst/extdata/OSD/P/POOSE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PORCH.json
+++ b/inst/extdata/OSD/P/PORCH.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PORTAGE.json
+++ b/inst/extdata/OSD/P/PORTAGE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PORTDICK.json
+++ b/inst/extdata/OSD/P/PORTDICK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PORTNEUF.json
+++ b/inst/extdata/OSD/P/PORTNEUF.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PORTOLA.json
+++ b/inst/extdata/OSD/P/PORTOLA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/POTTSBURG.json
+++ b/inst/extdata/OSD/P/POTTSBURG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
-        "drainage_overview": "somewhat poorly and poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/POUDRE.json
+++ b/inst/extdata/OSD/P/POUDRE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or poorly",
-        "drainage_overview": "poorly or somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/POWDERRIVER.json
+++ b/inst/extdata/OSD/P/POWDERRIVER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PRADE.json
+++ b/inst/extdata/OSD/P/PRADE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PRAG.json
+++ b/inst/extdata/OSD/P/PRAG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PRAIRIE.json
+++ b/inst/extdata/OSD/P/PRAIRIE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PREAKNESS.json
+++ b/inst/extdata/OSD/P/PREAKNESS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PREATORSON.json
+++ b/inst/extdata/OSD/P/PREATORSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PREBISH.json
+++ b/inst/extdata/OSD/P/PREBISH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PRESTON.json
+++ b/inst/extdata/OSD/P/PRESTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively or somewhat excessively",
-        "drainage_overview": "excessively and somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PRIESTGRADE.json
+++ b/inst/extdata/OSD/P/PRIESTGRADE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PRIESTLAKE.json
+++ b/inst/extdata/OSD/P/PRIESTLAKE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PRITCHETT.json
+++ b/inst/extdata/OSD/P/PRITCHETT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PROMO.json
+++ b/inst/extdata/OSD/P/PROMO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PUAPUA.json
+++ b/inst/extdata/OSD/P/PUAPUA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PUCKUM.json
+++ b/inst/extdata/OSD/P/PUCKUM.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": ""
+        "drainage_overview": "very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PUDDLE.json
+++ b/inst/extdata/OSD/P/PUDDLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PUERCO.json
+++ b/inst/extdata/OSD/P/PUERCO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PULLBACK.json
+++ b/inst/extdata/OSD/P/PULLBACK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PULLOUT.json
+++ b/inst/extdata/OSD/P/PULLOUT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and somewhat poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PULS.json
+++ b/inst/extdata/OSD/P/PULS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PULSIPHER.json
+++ b/inst/extdata/OSD/P/PULSIPHER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PURCHASE.json
+++ b/inst/extdata/OSD/P/PURCHASE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
-        "drainage_overview": "moderately well to well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PURCHES.json
+++ b/inst/extdata/OSD/P/PURCHES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PURDY.json
+++ b/inst/extdata/OSD/P/PURDY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/P/PURVES.json
+++ b/inst/extdata/OSD/P/PURVES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/P/PUSTOI.json
+++ b/inst/extdata/OSD/P/PUSTOI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/P/PYLE.json
+++ b/inst/extdata/OSD/P/PYLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/Q/QUAM.json
+++ b/inst/extdata/OSD/Q/QUAM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/Q/QUEALMAN.json
+++ b/inst/extdata/OSD/Q/QUEALMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "somewhat poorly to moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/Q/QUEENY.json
+++ b/inst/extdata/OSD/Q/QUEENY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Q/QUIBURI.json
+++ b/inst/extdata/OSD/Q/QUIBURI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/Q/QUIETUS.json
+++ b/inst/extdata/OSD/Q/QUIETUS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Q/QUIMA.json
+++ b/inst/extdata/OSD/Q/QUIMA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Q/QUIVER.json
+++ b/inst/extdata/OSD/Q/QUIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/Q/QUTAL.json
+++ b/inst/extdata/OSD/Q/QUTAL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat poorly",
-        "drainage_overview": ""
+        "drainage_overview": "somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RACE.json
+++ b/inst/extdata/OSD/R/RACE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RACKET.json
+++ b/inst/extdata/OSD/R/RACKET.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well and moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RADIOVILLE.json
+++ b/inst/extdata/OSD/R/RADIOVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RAGGEDROCK.json
+++ b/inst/extdata/OSD/R/RAGGEDROCK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RAGO.json
+++ b/inst/extdata/OSD/R/RAGO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RAINEY.json
+++ b/inst/extdata/OSD/R/RAINEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/RAMELLI.json
+++ b/inst/extdata/OSD/R/RAMELLI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RAMONA.json
+++ b/inst/extdata/OSD/R/RAMONA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/RAMSHORN.json
+++ b/inst/extdata/OSD/R/RAMSHORN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/RANES.json
+++ b/inst/extdata/OSD/R/RANES.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RANGER.json
+++ b/inst/extdata/OSD/R/RANGER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/RAPID.json
+++ b/inst/extdata/OSD/R/RAPID.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/RAPIDCREEK.json
+++ b/inst/extdata/OSD/R/RAPIDCREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RARITAN.json
+++ b/inst/extdata/OSD/R/RARITAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RAZITO.json
+++ b/inst/extdata/OSD/R/RAZITO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/READING.json
+++ b/inst/extdata/OSD/R/READING.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well, moderately well",
         "drainage_overview": "well, moderately well"
       }
     ]

--- a/inst/extdata/OSD/R/READING.json
+++ b/inst/extdata/OSD/R/READING.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": "well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REAKOR.json
+++ b/inst/extdata/OSD/R/REAKOR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/REAVILLE.json
+++ b/inst/extdata/OSD/R/REAVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REBA.json
+++ b/inst/extdata/OSD/R/REBA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/REDDING.json
+++ b/inst/extdata/OSD/R/REDDING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REDFIELD.json
+++ b/inst/extdata/OSD/R/REDFIELD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REDFISH.json
+++ b/inst/extdata/OSD/R/REDFISH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REDMANSON.json
+++ b/inst/extdata/OSD/R/REDMANSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/REDNUN.json
+++ b/inst/extdata/OSD/R/REDNUN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REDTOM.json
+++ b/inst/extdata/OSD/R/REDTOM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REDTOP.json
+++ b/inst/extdata/OSD/R/REDTOP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/REDVIEW.json
+++ b/inst/extdata/OSD/R/REDVIEW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RED_HILL.json
+++ b/inst/extdata/OSD/R/RED_HILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/REGAN.json
+++ b/inst/extdata/OSD/R/REGAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REGGEAR.json
+++ b/inst/extdata/OSD/R/REGGEAR.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": ""
+        "drainage_overview": "moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REKOP.json
+++ b/inst/extdata/OSD/R/REKOP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/RELAN.json
+++ b/inst/extdata/OSD/R/RELAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/RELIZ.json
+++ b/inst/extdata/OSD/R/RELIZ.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REMEDIOS.json
+++ b/inst/extdata/OSD/R/REMEDIOS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REMMIT.json
+++ b/inst/extdata/OSD/R/REMMIT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/RENBAC.json
+++ b/inst/extdata/OSD/R/RENBAC.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/RENCALSON.json
+++ b/inst/extdata/OSD/R/RENCALSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/RENSSELAER.json
+++ b/inst/extdata/OSD/R/RENSSELAER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REPPART.json
+++ b/inst/extdata/OSD/R/REPPART.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/RESCUE.json
+++ b/inst/extdata/OSD/R/RESCUE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/RETRIEVER.json
+++ b/inst/extdata/OSD/R/RETRIEVER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/REXFORD.json
+++ b/inst/extdata/OSD/R/REXFORD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/REXVILLE.json
+++ b/inst/extdata/OSD/R/REXVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/R/RHOADES.json
+++ b/inst/extdata/OSD/R/RHOADES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RHODESFOLLY.json
+++ b/inst/extdata/OSD/R/RHODESFOLLY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RHODE_RIVER.json
+++ b/inst/extdata/OSD/R/RHODE_RIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RICH.json
+++ b/inst/extdata/OSD/R/RICH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RICHFORD.json
+++ b/inst/extdata/OSD/R/RICHFORD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RICKER.json
+++ b/inst/extdata/OSD/R/RICKER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RIDGEBURY.json
+++ b/inst/extdata/OSD/R/RIDGEBURY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "somewhat poorly and poorly"
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RIDIT.json
+++ b/inst/extdata/OSD/R/RIDIT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/RIESEL.json
+++ b/inst/extdata/OSD/R/RIESEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/RIGA.json
+++ b/inst/extdata/OSD/R/RIGA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/RIMFOREST.json
+++ b/inst/extdata/OSD/R/RIMFOREST.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RIN.json
+++ b/inst/extdata/OSD/R/RIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/RIPON.json
+++ b/inst/extdata/OSD/R/RIPON.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RIRIE.json
+++ b/inst/extdata/OSD/R/RIRIE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/RITO.json
+++ b/inst/extdata/OSD/R/RITO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/RIVIERA.json
+++ b/inst/extdata/OSD/R/RIVIERA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/R/RIZ.json
+++ b/inst/extdata/OSD/R/RIZ.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/RIZOZO.json
+++ b/inst/extdata/OSD/R/RIZOZO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/ROBANA.json
+++ b/inst/extdata/OSD/R/ROBANA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/ROBCO.json
+++ b/inst/extdata/OSD/R/ROBCO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/R/ROCKAWAY.json
+++ b/inst/extdata/OSD/R/ROCKAWAY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROCKBOTTOM.json
+++ b/inst/extdata/OSD/R/ROCKBOTTOM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROCKFORD.json
+++ b/inst/extdata/OSD/R/ROCKFORD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/ROCKLIN.json
+++ b/inst/extdata/OSD/R/ROCKLIN.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well or moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROCKUS.json
+++ b/inst/extdata/OSD/R/ROCKUS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/ROCKWELL.json
+++ b/inst/extdata/OSD/R/ROCKWELL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROCKYBAR.json
+++ b/inst/extdata/OSD/R/ROCKYBAR.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROFORK.json
+++ b/inst/extdata/OSD/R/ROFORK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat excessively",
-        "drainage_overview": "somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROLISS.json
+++ b/inst/extdata/OSD/R/ROLISS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROLLAWAY.json
+++ b/inst/extdata/OSD/R/ROLLAWAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROME.json
+++ b/inst/extdata/OSD/R/ROME.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/ROMNELL.json
+++ b/inst/extdata/OSD/R/ROMNELL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROND.json
+++ b/inst/extdata/OSD/R/ROND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/ROOT.json
+++ b/inst/extdata/OSD/R/ROOT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROOTEL.json
+++ b/inst/extdata/OSD/R/ROOTEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/ROSCOMMON.json
+++ b/inst/extdata/OSD/R/ROSCOMMON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROSEGLEN.json
+++ b/inst/extdata/OSD/R/ROSEGLEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROSEWOOD.json
+++ b/inst/extdata/OSD/R/ROSEWOOD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROSMAN.json
+++ b/inst/extdata/OSD/R/ROSMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROSSVILLE.json
+++ b/inst/extdata/OSD/R/ROSSVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/ROTTULEE.json
+++ b/inst/extdata/OSD/R/ROTTULEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROUGHCREEK.json
+++ b/inst/extdata/OSD/R/ROUGHCREEK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/ROUNDABOUT.json
+++ b/inst/extdata/OSD/R/ROUNDABOUT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROUNDMEADOW.json
+++ b/inst/extdata/OSD/R/ROUNDMEADOW.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROUNDTOP.json
+++ b/inst/extdata/OSD/R/ROUNDTOP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/ROUNDVAL.json
+++ b/inst/extdata/OSD/R/ROUNDVAL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
-        "drainage_overview": "somewhat poorly and poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROVAL.json
+++ b/inst/extdata/OSD/R/ROVAL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROWE.json
+++ b/inst/extdata/OSD/R/ROWE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROWLAND.json
+++ b/inst/extdata/OSD/R/ROWLAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROXBURY.json
+++ b/inst/extdata/OSD/R/ROXBURY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/ROYOSA.json
+++ b/inst/extdata/OSD/R/ROYOSA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat excessively",
-        "drainage_overview": "excessively or somewhat excessively"
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RUBIO.json
+++ b/inst/extdata/OSD/R/RUBIO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RUBSON.json
+++ b/inst/extdata/OSD/R/RUBSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/R/RUDEEN.json
+++ b/inst/extdata/OSD/R/RUDEEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/R/RUMFORD.json
+++ b/inst/extdata/OSD/R/RUMFORD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RUNEBERG.json
+++ b/inst/extdata/OSD/R/RUNEBERG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RUSE.json
+++ b/inst/extdata/OSD/R/RUSE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RUSHVILLE.json
+++ b/inst/extdata/OSD/R/RUSHVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RUTAN.json
+++ b/inst/extdata/OSD/R/RUTAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RYAN_PARK.json
+++ b/inst/extdata/OSD/R/RYAN_PARK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RYARK.json
+++ b/inst/extdata/OSD/R/RYARK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well and somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/R/RYORP.json
+++ b/inst/extdata/OSD/R/RYORP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SACAHUISTA.json
+++ b/inst/extdata/OSD/S/SACAHUISTA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SAGANING.json
+++ b/inst/extdata/OSD/S/SAGANING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SAGUACHE.json
+++ b/inst/extdata/OSD/S/SAGUACHE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SAHUARITA.json
+++ b/inst/extdata/OSD/S/SAHUARITA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SALCO.json
+++ b/inst/extdata/OSD/S/SALCO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SALLYANN.json
+++ b/inst/extdata/OSD/S/SALLYANN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SALMO.json
+++ b/inst/extdata/OSD/S/SALMO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SALTAIR.json
+++ b/inst/extdata/OSD/S/SALTAIR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SALT_LAKE.json
+++ b/inst/extdata/OSD/S/SALT_LAKE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/S/SALVISA.json
+++ b/inst/extdata/OSD/S/SALVISA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SANDFLY.json
+++ b/inst/extdata/OSD/S/SANDFLY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SANDIA.json
+++ b/inst/extdata/OSD/S/SANDIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SAND_POINT.json
+++ b/inst/extdata/OSD/S/SAND_POINT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SANMOSS.json
+++ b/inst/extdata/OSD/S/SANMOSS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SANPETE.json
+++ b/inst/extdata/OSD/S/SANPETE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SANPITCH.json
+++ b/inst/extdata/OSD/S/SANPITCH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SANPOIL.json
+++ b/inst/extdata/OSD/S/SANPOIL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SANTANONI.json
+++ b/inst/extdata/OSD/S/SANTANONI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively and excessively",
-        "drainage_overview": "somewhat excessively and excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SANTA_LUCIA.json
+++ b/inst/extdata/OSD/S/SANTA_LUCIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SANTO_TOMAS.json
+++ b/inst/extdata/OSD/S/SANTO_TOMAS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SAN_BENITO.json
+++ b/inst/extdata/OSD/S/SAN_BENITO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SAN_ISABEL.json
+++ b/inst/extdata/OSD/S/SAN_ISABEL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SAN_JOAQUIN.json
+++ b/inst/extdata/OSD/S/SAN_JOAQUIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SAN_LUIS.json
+++ b/inst/extdata/OSD/S/SAN_LUIS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/S/SAN_MIGUEL.json
+++ b/inst/extdata/OSD/S/SAN_MIGUEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SAN_TIMOTEO.json
+++ b/inst/extdata/OSD/S/SAN_TIMOTEO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SAPELO.json
+++ b/inst/extdata/OSD/S/SAPELO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly and poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SARANAC.json
+++ b/inst/extdata/OSD/S/SARANAC.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SARCOXIE.json
+++ b/inst/extdata/OSD/S/SARCOXIE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/S/SATTLEY.json
+++ b/inst/extdata/OSD/S/SATTLEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SAUK.json
+++ b/inst/extdata/OSD/S/SAUK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SAULICH.json
+++ b/inst/extdata/OSD/S/SAULICH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SAVOIA.json
+++ b/inst/extdata/OSD/S/SAVOIA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SAWCREEK.json
+++ b/inst/extdata/OSD/S/SAWCREEK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SAWMILL.json
+++ b/inst/extdata/OSD/S/SAWMILL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SAYLES.json
+++ b/inst/extdata/OSD/S/SAYLES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SCATTERSVILLE.json
+++ b/inst/extdata/OSD/S/SCATTERSVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/S/SCHAMBER.json
+++ b/inst/extdata/OSD/S/SCHAMBER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SCHMUTZ.json
+++ b/inst/extdata/OSD/S/SCHMUTZ.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SCHNEBLY.json
+++ b/inst/extdata/OSD/S/SCHNEBLY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SCHOONER.json
+++ b/inst/extdata/OSD/S/SCHOONER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
-        "drainage_overview": "well to excessively"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SCHROCK.json
+++ b/inst/extdata/OSD/S/SCHROCK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SCOTT.json
+++ b/inst/extdata/OSD/S/SCOTT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly, very poorly"
       }
     ]

--- a/inst/extdata/OSD/S/SCOTT.json
+++ b/inst/extdata/OSD/S/SCOTT.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SCOTTY.json
+++ b/inst/extdata/OSD/S/SCOTTY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively to well",
-        "drainage_overview": "somewhat excessively to well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SCRIVER.json
+++ b/inst/extdata/OSD/S/SCRIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SEAGATE.json
+++ b/inst/extdata/OSD/S/SEAGATE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SEBEWA.json
+++ b/inst/extdata/OSD/S/SEBEWA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SEBREE.json
+++ b/inst/extdata/OSD/S/SEBREE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SECCA.json
+++ b/inst/extdata/OSD/S/SECCA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SECREST.json
+++ b/inst/extdata/OSD/S/SECREST.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SEDGEVILLE.json
+++ b/inst/extdata/OSD/S/SEDGEVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SEEDSKADEE.json
+++ b/inst/extdata/OSD/S/SEEDSKADEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SEELEZ.json
+++ b/inst/extdata/OSD/S/SEELEZ.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SELLMAN.json
+++ b/inst/extdata/OSD/S/SELLMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SEMINOLE.json
+++ b/inst/extdata/OSD/S/SEMINOLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/S/SESPE.json
+++ b/inst/extdata/OSD/S/SESPE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SETTERS.json
+++ b/inst/extdata/OSD/S/SETTERS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/S/SEVAL.json
+++ b/inst/extdata/OSD/S/SEVAL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SHAKAN.json
+++ b/inst/extdata/OSD/S/SHAKAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "moderately well to well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHAMEL.json
+++ b/inst/extdata/OSD/S/SHAMEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SHANDEP.json
+++ b/inst/extdata/OSD/S/SHANDEP.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHANKLER.json
+++ b/inst/extdata/OSD/S/SHANKLER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHANNOCK.json
+++ b/inst/extdata/OSD/S/SHANNOCK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHARKEY.json
+++ b/inst/extdata/OSD/S/SHARKEY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": "poorly and very poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHARLAND.json
+++ b/inst/extdata/OSD/S/SHARLAND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SHATTUCK.json
+++ b/inst/extdata/OSD/S/SHATTUCK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHAWA.json
+++ b/inst/extdata/OSD/S/SHAWA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHEDD.json
+++ b/inst/extdata/OSD/S/SHEDD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SHELL.json
+++ b/inst/extdata/OSD/S/SHELL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SHELLBLUFF.json
+++ b/inst/extdata/OSD/S/SHELLBLUFF.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHELLEY.json
+++ b/inst/extdata/OSD/S/SHELLEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively to excessively",
-        "drainage_overview": "somewhat excessively to excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHERANDO.json
+++ b/inst/extdata/OSD/S/SHERANDO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHERBURNE.json
+++ b/inst/extdata/OSD/S/SHERBURNE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SHERDAHL.json
+++ b/inst/extdata/OSD/S/SHERDAHL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SHERIDAN.json
+++ b/inst/extdata/OSD/S/SHERIDAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SHERRY.json
+++ b/inst/extdata/OSD/S/SHERRY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHERRYL.json
+++ b/inst/extdata/OSD/S/SHERRYL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SHILOH.json
+++ b/inst/extdata/OSD/S/SHILOH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHINGLEHOUSE.json
+++ b/inst/extdata/OSD/S/SHINGLEHOUSE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or moderately well",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHINUME.json
+++ b/inst/extdata/OSD/S/SHINUME.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively to well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/S/SHIPROCK.json
+++ b/inst/extdata/OSD/S/SHIPROCK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHIPS.json
+++ b/inst/extdata/OSD/S/SHIPS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/S/SHIRLEY.json
+++ b/inst/extdata/OSD/S/SHIRLEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHOALWATER.json
+++ b/inst/extdata/OSD/S/SHOALWATER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/S/SHOREWOOD.json
+++ b/inst/extdata/OSD/S/SHOREWOOD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHORTNAP.json
+++ b/inst/extdata/OSD/S/SHORTNAP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/S/SHOSHONE.json
+++ b/inst/extdata/OSD/S/SHOSHONE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
-        "drainage_overview": "somewhat poorly or poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SHOWALTER.json
+++ b/inst/extdata/OSD/S/SHOWALTER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SHREWSBURY.json
+++ b/inst/extdata/OSD/S/SHREWSBURY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": ""
+        "drainage_overview": "poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SIBBETT.json
+++ b/inst/extdata/OSD/S/SIBBETT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/S/SICKLES.json
+++ b/inst/extdata/OSD/S/SICKLES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SIDEHILL.json
+++ b/inst/extdata/OSD/S/SIDEHILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SIERRAVILLE.json
+++ b/inst/extdata/OSD/S/SIERRAVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SIEVERS.json
+++ b/inst/extdata/OSD/S/SIEVERS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/S/SILVERCLIFF.json
+++ b/inst/extdata/OSD/S/SILVERCLIFF.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SIMMONT.json
+++ b/inst/extdata/OSD/S/SIMMONT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to excessively",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SIMS.json
+++ b/inst/extdata/OSD/S/SIMS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SINAI.json
+++ b/inst/extdata/OSD/S/SINAI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SINAMOX.json
+++ b/inst/extdata/OSD/S/SINAMOX.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SINEPUXENT.json
+++ b/inst/extdata/OSD/S/SINEPUXENT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SINONA.json
+++ b/inst/extdata/OSD/S/SINONA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SITES.json
+++ b/inst/extdata/OSD/S/SITES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SIXMILE.json
+++ b/inst/extdata/OSD/S/SIXMILE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SIZER.json
+++ b/inst/extdata/OSD/S/SIZER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SKIDMORE.json
+++ b/inst/extdata/OSD/S/SKIDMORE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SKOWHEGAN.json
+++ b/inst/extdata/OSD/S/SKOWHEGAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SKUTUM.json
+++ b/inst/extdata/OSD/S/SKUTUM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SKYLAND.json
+++ b/inst/extdata/OSD/S/SKYLAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SKYLICK.json
+++ b/inst/extdata/OSD/S/SKYLICK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SKYLIGHT.json
+++ b/inst/extdata/OSD/S/SKYLIGHT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively and excessively",
-        "drainage_overview": "somewhat excessively and excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SKYLINE.json
+++ b/inst/extdata/OSD/S/SKYLINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SKYMOR.json
+++ b/inst/extdata/OSD/S/SKYMOR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SLIPMAN.json
+++ b/inst/extdata/OSD/S/SLIPMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SLUICE.json
+++ b/inst/extdata/OSD/S/SLUICE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SMILEY.json
+++ b/inst/extdata/OSD/S/SMILEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SMOKEHOUSE.json
+++ b/inst/extdata/OSD/S/SMOKEHOUSE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SMOLAN.json
+++ b/inst/extdata/OSD/S/SMOLAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SMYRNA.json
+++ b/inst/extdata/OSD/S/SMYRNA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to very poorly",
-        "drainage_overview": "poorly to very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SNAG.json
+++ b/inst/extdata/OSD/S/SNAG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SNAPP.json
+++ b/inst/extdata/OSD/S/SNAPP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SNOWDANCE.json
+++ b/inst/extdata/OSD/S/SNOWDANCE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SNOWVILLE.json
+++ b/inst/extdata/OSD/S/SNOWVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SODAWELLS.json
+++ b/inst/extdata/OSD/S/SODAWELLS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SOFIA.json
+++ b/inst/extdata/OSD/S/SOFIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SOGI.json
+++ b/inst/extdata/OSD/S/SOGI.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SOLDIER.json
+++ b/inst/extdata/OSD/S/SOLDIER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SOO.json
+++ b/inst/extdata/OSD/S/SOO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SORF.json
+++ b/inst/extdata/OSD/S/SORF.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SOUTHFORK.json
+++ b/inst/extdata/OSD/S/SOUTHFORK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SOUTHPOINT.json
+++ b/inst/extdata/OSD/S/SOUTHPOINT.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "very poorly",
-        "drainage_overview": ""
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SOUTH_RIVER.json
+++ b/inst/extdata/OSD/S/SOUTH_RIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SOWEGO.json
+++ b/inst/extdata/OSD/S/SOWEGO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPANEL.json
+++ b/inst/extdata/OSD/S/SPANEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SPANGENBURG.json
+++ b/inst/extdata/OSD/S/SPANGENBURG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPARTABUTTE.json
+++ b/inst/extdata/OSD/S/SPARTABUTTE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPEARFISH.json
+++ b/inst/extdata/OSD/S/SPEARFISH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPEARMAN.json
+++ b/inst/extdata/OSD/S/SPEARMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SPEARVILLE.json
+++ b/inst/extdata/OSD/S/SPEARVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPERRY.json
+++ b/inst/extdata/OSD/S/SPERRY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPICER.json
+++ b/inst/extdata/OSD/S/SPICER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPICERTON.json
+++ b/inst/extdata/OSD/S/SPICERTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to moderately well",
-        "drainage_overview": "well to moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPIKEBOX.json
+++ b/inst/extdata/OSD/S/SPIKEBOX.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SPILLCO.json
+++ b/inst/extdata/OSD/S/SPILLCO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPILLVILLE.json
+++ b/inst/extdata/OSD/S/SPILLVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPIRES.json
+++ b/inst/extdata/OSD/S/SPIRES.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SPLENDORA.json
+++ b/inst/extdata/OSD/S/SPLENDORA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPOKANE.json
+++ b/inst/extdata/OSD/S/SPOKANE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SPOOLSVILLE.json
+++ b/inst/extdata/OSD/S/SPOOLSVILLE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SPRAGUERIVER.json
+++ b/inst/extdata/OSD/S/SPRAGUERIVER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/S/SPRINGMEADOW.json
+++ b/inst/extdata/OSD/S/SPRINGMEADOW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/S/SQUATTERFLAT.json
+++ b/inst/extdata/OSD/S/SQUATTERFLAT.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/ST._GEORGE.json
+++ b/inst/extdata/OSD/S/ST._GEORGE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/ST._JOHNS.json
+++ b/inst/extdata/OSD/S/ST._JOHNS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/ST._ONGE.json
+++ b/inst/extdata/OSD/S/ST._ONGE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STALTER.json
+++ b/inst/extdata/OSD/S/STALTER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STAVELY.json
+++ b/inst/extdata/OSD/S/STAVELY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STEED.json
+++ b/inst/extdata/OSD/S/STEED.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/STEEDMAN.json
+++ b/inst/extdata/OSD/S/STEEDMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STEEKEE.json
+++ b/inst/extdata/OSD/S/STEEKEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STEPHEN.json
+++ b/inst/extdata/OSD/S/STEPHEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/STEPROCK.json
+++ b/inst/extdata/OSD/S/STEPROCK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/STERLING.json
+++ b/inst/extdata/OSD/S/STERLING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STETSON.json
+++ b/inst/extdata/OSD/S/STETSON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STEVENSGULCH.json
+++ b/inst/extdata/OSD/S/STEVENSGULCH.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STIRK.json
+++ b/inst/extdata/OSD/S/STIRK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STIRUM.json
+++ b/inst/extdata/OSD/S/STIRUM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STITHUM.json
+++ b/inst/extdata/OSD/S/STITHUM.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STORLA.json
+++ b/inst/extdata/OSD/S/STORLA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STORMITT.json
+++ b/inst/extdata/OSD/S/STORMITT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/STOUT.json
+++ b/inst/extdata/OSD/S/STOUT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STRATHCONA.json
+++ b/inst/extdata/OSD/S/STRATHCONA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STRAW.json
+++ b/inst/extdata/OSD/S/STRAW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STREVELL.json
+++ b/inst/extdata/OSD/S/STREVELL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/STUTTGART.json
+++ b/inst/extdata/OSD/S/STUTTGART.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUBLETTE.json
+++ b/inst/extdata/OSD/S/SUBLETTE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SUCCOTASH.json
+++ b/inst/extdata/OSD/S/SUCCOTASH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/S/SUCHES.json
+++ b/inst/extdata/OSD/S/SUCHES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUCKERCREEK.json
+++ b/inst/extdata/OSD/S/SUCKERCREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUDBURY.json
+++ b/inst/extdata/OSD/S/SUDBURY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUDPEAK.json
+++ b/inst/extdata/OSD/S/SUDPEAK.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": ""
+        "drainage_overview": "moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUGUN.json
+++ b/inst/extdata/OSD/S/SUGUN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUMERDUCK.json
+++ b/inst/extdata/OSD/S/SUMERDUCK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUMMIT.json
+++ b/inst/extdata/OSD/S/SUMMIT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUMMITVILLE.json
+++ b/inst/extdata/OSD/S/SUMMITVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUMTER.json
+++ b/inst/extdata/OSD/S/SUMTER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "moderately well or well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUNEV.json
+++ b/inst/extdata/OSD/S/SUNEV.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SUNSET.json
+++ b/inst/extdata/OSD/S/SUNSET.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUNSETCONE.json
+++ b/inst/extdata/OSD/S/SUNSETCONE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SURPLUS.json
+++ b/inst/extdata/OSD/S/SURPLUS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SUTHERLAND.json
+++ b/inst/extdata/OSD/S/SUTHERLAND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SUTPHEN.json
+++ b/inst/extdata/OSD/S/SUTPHEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/S/SVEA.json
+++ b/inst/extdata/OSD/S/SVEA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SWANBOY.json
+++ b/inst/extdata/OSD/S/SWANBOY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
-        "drainage_overview": "moderately well or well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SWANTON.json
+++ b/inst/extdata/OSD/S/SWANTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SWARTSWOOD.json
+++ b/inst/extdata/OSD/S/SWARTSWOOD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SWASEY.json
+++ b/inst/extdata/OSD/S/SWASEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SWEDNA.json
+++ b/inst/extdata/OSD/S/SWEDNA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SWEEN.json
+++ b/inst/extdata/OSD/S/SWEEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SWEETCREEK.json
+++ b/inst/extdata/OSD/S/SWEETCREEK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SWENODA.json
+++ b/inst/extdata/OSD/S/SWENODA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SWIFTON.json
+++ b/inst/extdata/OSD/S/SWIFTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SWIFT_CREEK.json
+++ b/inst/extdata/OSD/S/SWIFT_CREEK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/S/SWILLNA.json
+++ b/inst/extdata/OSD/S/SWILLNA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SWINT.json
+++ b/inst/extdata/OSD/S/SWINT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SWISBOB.json
+++ b/inst/extdata/OSD/S/SWISBOB.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/S/SYCOLINE.json
+++ b/inst/extdata/OSD/S/SYCOLINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
-        "drainage_overview": "moderately well to somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/S/SYRENE.json
+++ b/inst/extdata/OSD/S/SYRENE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TABLE_MOUNTAIN.json
+++ b/inst/extdata/OSD/T/TABLE_MOUNTAIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TACAN.json
+++ b/inst/extdata/OSD/T/TACAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TADKEE.json
+++ b/inst/extdata/OSD/T/TADKEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TAFUNA.json
+++ b/inst/extdata/OSD/T/TAFUNA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TAHQUATS.json
+++ b/inst/extdata/OSD/T/TAHQUATS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TALAG.json
+++ b/inst/extdata/OSD/T/TALAG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TALAWA.json
+++ b/inst/extdata/OSD/T/TALAWA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to very poorly",
-        "drainage_overview": "poorly to very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TALCOT.json
+++ b/inst/extdata/OSD/T/TALCOT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TALLAC.json
+++ b/inst/extdata/OSD/T/TALLAC.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TALMOON.json
+++ b/inst/extdata/OSD/T/TALMOON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TALUWIK.json
+++ b/inst/extdata/OSD/T/TALUWIK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TAMELY.json
+++ b/inst/extdata/OSD/T/TAMELY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TAMRED.json
+++ b/inst/extdata/OSD/T/TAMRED.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TANACROSS.json
+++ b/inst/extdata/OSD/T/TANACROSS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TANGOE.json
+++ b/inst/extdata/OSD/T/TANGOE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or somewhat poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TASSEL.json
+++ b/inst/extdata/OSD/T/TASSEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TASSO.json
+++ b/inst/extdata/OSD/T/TASSO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TATLANIKA.json
+++ b/inst/extdata/OSD/T/TATLANIKA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or very poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage": "very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TAWAH.json
+++ b/inst/extdata/OSD/T/TAWAH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TAYLORSVILLE.json
+++ b/inst/extdata/OSD/T/TAYLORSVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TEAPO.json
+++ b/inst/extdata/OSD/T/TEAPO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TEA_HAMMOCK.json
+++ b/inst/extdata/OSD/T/TEA_HAMMOCK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TEHAMA.json
+++ b/inst/extdata/OSD/T/TEHAMA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TELEMON.json
+++ b/inst/extdata/OSD/T/TELEMON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TELEPHONE.json
+++ b/inst/extdata/OSD/T/TELEPHONE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TELF.json
+++ b/inst/extdata/OSD/T/TELF.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/T/TELFER.json
+++ b/inst/extdata/OSD/T/TELFER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively and somewhat excessively",
-        "drainage_overview": "excessively and somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TEMESCAL.json
+++ b/inst/extdata/OSD/T/TEMESCAL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TENRAG.json
+++ b/inst/extdata/OSD/T/TENRAG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TERRIL.json
+++ b/inst/extdata/OSD/T/TERRIL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TERTOO.json
+++ b/inst/extdata/OSD/T/TERTOO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TESAJO.json
+++ b/inst/extdata/OSD/T/TESAJO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat excessively",
-        "drainage_overview": "moderately well to somewhat excessively"
+        "drainage": "somewhat excessively, well, moderately well",
+        "drainage_overview": "somewhat excessively, well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TETONIA.json
+++ b/inst/extdata/OSD/T/TETONIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TEX.json
+++ b/inst/extdata/OSD/T/TEX.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TEXANA.json
+++ b/inst/extdata/OSD/T/TEXANA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/T/THAYNE.json
+++ b/inst/extdata/OSD/T/THAYNE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/THIEFRIVER.json
+++ b/inst/extdata/OSD/T/THIEFRIVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/THIEL.json
+++ b/inst/extdata/OSD/T/THIEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/THOMAS.json
+++ b/inst/extdata/OSD/T/THOMAS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/THOMS.json
+++ b/inst/extdata/OSD/T/THOMS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/THREECABIN.json
+++ b/inst/extdata/OSD/T/THREECABIN.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/THREECENT.json
+++ b/inst/extdata/OSD/T/THREECENT.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/THURLOW.json
+++ b/inst/extdata/OSD/T/THURLOW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TICHNOR.json
+++ b/inst/extdata/OSD/T/TICHNOR.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly or very poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TICKAPOO.json
+++ b/inst/extdata/OSD/T/TICKAPOO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TIGIWON.json
+++ b/inst/extdata/OSD/T/TIGIWON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TILFER.json
+++ b/inst/extdata/OSD/T/TILFER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TIMBLIN.json
+++ b/inst/extdata/OSD/T/TIMBLIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TIMPANOGOS.json
+++ b/inst/extdata/OSD/T/TIMPANOGOS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TINE.json
+++ b/inst/extdata/OSD/T/TINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TINEMAN.json
+++ b/inst/extdata/OSD/T/TINEMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TINGEY.json
+++ b/inst/extdata/OSD/T/TINGEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TINGLES.json
+++ b/inst/extdata/OSD/T/TINGLES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TINKER.json
+++ b/inst/extdata/OSD/T/TINKER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TINN.json
+++ b/inst/extdata/OSD/T/TINN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/T/TIPPER.json
+++ b/inst/extdata/OSD/T/TIPPER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TIPPERARY.json
+++ b/inst/extdata/OSD/T/TIPPERARY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively",
+        "drainage": "excessively, somewhat excessively",
         "drainage_overview": "somewhat excessively"
       }
     ]

--- a/inst/extdata/OSD/T/TITLOW.json
+++ b/inst/extdata/OSD/T/TITLOW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TOBICO.json
+++ b/inst/extdata/OSD/T/TOBICO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOBINCREEK.json
+++ b/inst/extdata/OSD/T/TOBINCREEK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TOBISH.json
+++ b/inst/extdata/OSD/T/TOBISH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TOBLER.json
+++ b/inst/extdata/OSD/T/TOBLER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TOBOSA.json
+++ b/inst/extdata/OSD/T/TOBOSA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TOCCOA.json
+++ b/inst/extdata/OSD/T/TOCCOA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TODDLER.json
+++ b/inst/extdata/OSD/T/TODDLER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TODOS.json
+++ b/inst/extdata/OSD/T/TODOS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TOEBRANCH.json
+++ b/inst/extdata/OSD/T/TOEBRANCH.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOINETTE.json
+++ b/inst/extdata/OSD/T/TOINETTE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOKO.json
+++ b/inst/extdata/OSD/T/TOKO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOLLAND.json
+++ b/inst/extdata/OSD/T/TOLLAND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TOLLHOUSE.json
+++ b/inst/extdata/OSD/T/TOLLHOUSE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat excessively or excessively",
-        "drainage_overview": "somewhat excessively or excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOLSONA.json
+++ b/inst/extdata/OSD/T/TOLSONA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOLSTOI.json
+++ b/inst/extdata/OSD/T/TOLSTOI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOLUCA.json
+++ b/inst/extdata/OSD/T/TOLUCA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TOMAHAWK.json
+++ b/inst/extdata/OSD/T/TOMAHAWK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOMERA.json
+++ b/inst/extdata/OSD/T/TOMERA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TOMICHI.json
+++ b/inst/extdata/OSD/T/TOMICHI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOMSHERRY.json
+++ b/inst/extdata/OSD/T/TOMSHERRY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TONEY.json
+++ b/inst/extdata/OSD/T/TONEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "moderately well",
+        "drainage_overview": "moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TONKEY.json
+++ b/inst/extdata/OSD/T/TONKEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TONKIN.json
+++ b/inst/extdata/OSD/T/TONKIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TONOPAH.json
+++ b/inst/extdata/OSD/T/TONOPAH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively to well",
-        "drainage_overview": "excessively to well"
+        "drainage": "excessively, somewhat excessively, well",
+        "drainage_overview": "excessively, somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TONRA.json
+++ b/inst/extdata/OSD/T/TONRA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TOOLES.json
+++ b/inst/extdata/OSD/T/TOOLES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOOLESBORO.json
+++ b/inst/extdata/OSD/T/TOOLESBORO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOOMES.json
+++ b/inst/extdata/OSD/T/TOOMES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TORCHLIGHT.json
+++ b/inst/extdata/OSD/T/TORCHLIGHT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TORTUGAS.json
+++ b/inst/extdata/OSD/T/TORTUGAS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TOSSUP.json
+++ b/inst/extdata/OSD/T/TOSSUP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TOTAGATIC.json
+++ b/inst/extdata/OSD/T/TOTAGATIC.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOTATLANIKA.json
+++ b/inst/extdata/OSD/T/TOTATLANIKA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly or poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOURS.json
+++ b/inst/extdata/OSD/T/TOURS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TOUZALIN.json
+++ b/inst/extdata/OSD/T/TOUZALIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/T/TOWAOC.json
+++ b/inst/extdata/OSD/T/TOWAOC.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOWERMOUNTAIN.json
+++ b/inst/extdata/OSD/T/TOWERMOUNTAIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOWNER.json
+++ b/inst/extdata/OSD/T/TOWNER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TOXAWAY.json
+++ b/inst/extdata/OSD/T/TOXAWAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TRACOSA.json
+++ b/inst/extdata/OSD/T/TRACOSA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/T/TRAER.json
+++ b/inst/extdata/OSD/T/TRAER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TRAIL.json
+++ b/inst/extdata/OSD/T/TRAIL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TRAITORS.json
+++ b/inst/extdata/OSD/T/TRAITORS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TRANSYLVANIA.json
+++ b/inst/extdata/OSD/T/TRANSYLVANIA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TRAPPE.json
+++ b/inst/extdata/OSD/T/TRAPPE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TRAVELERS.json
+++ b/inst/extdata/OSD/T/TRAVELERS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TRAVER.json
+++ b/inst/extdata/OSD/T/TRAVER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TRAY.json
+++ b/inst/extdata/OSD/T/TRAY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TREMBLES.json
+++ b/inst/extdata/OSD/T/TREMBLES.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TREMONA.json
+++ b/inst/extdata/OSD/T/TREMONA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/T/TRENT.json
+++ b/inst/extdata/OSD/T/TRENT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TRENTON.json
+++ b/inst/extdata/OSD/T/TRENTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/T/TREON.json
+++ b/inst/extdata/OSD/T/TREON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TRETTEN.json
+++ b/inst/extdata/OSD/T/TRETTEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TRIMBLE.json
+++ b/inst/extdata/OSD/T/TRIMBLE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TRIMMER.json
+++ b/inst/extdata/OSD/T/TRIMMER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/T/TRINITY.json
+++ b/inst/extdata/OSD/T/TRINITY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/T/TRIPIT.json
+++ b/inst/extdata/OSD/T/TRIPIT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TRIPLEN.json
+++ b/inst/extdata/OSD/T/TRIPLEN.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TROSI.json
+++ b/inst/extdata/OSD/T/TROSI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TROUTVILLE.json
+++ b/inst/extdata/OSD/T/TROUTVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TRUCKTON.json
+++ b/inst/extdata/OSD/T/TRUCKTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TRUEFISSURE.json
+++ b/inst/extdata/OSD/T/TRUEFISSURE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TRUITT.json
+++ b/inst/extdata/OSD/T/TRUITT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TRULON.json
+++ b/inst/extdata/OSD/T/TRULON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TRYON.json
+++ b/inst/extdata/OSD/T/TRYON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TSAMMANA.json
+++ b/inst/extdata/OSD/T/TSAMMANA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TSUNAMI.json
+++ b/inst/extdata/OSD/T/TSUNAMI.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TUCANNON.json
+++ b/inst/extdata/OSD/T/TUCANNON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TUCKERTOWN.json
+++ b/inst/extdata/OSD/T/TUCKERTOWN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TUCUPIT.json
+++ b/inst/extdata/OSD/T/TUCUPIT.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TULIK.json
+++ b/inst/extdata/OSD/T/TULIK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TUMAGAN.json
+++ b/inst/extdata/OSD/T/TUMAGAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TUNKHANNOCK.json
+++ b/inst/extdata/OSD/T/TUNKHANNOCK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TURK.json
+++ b/inst/extdata/OSD/T/TURK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/T/TURKEYSPRINGS.json
+++ b/inst/extdata/OSD/T/TURKEYSPRINGS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TURNBACK.json
+++ b/inst/extdata/OSD/T/TURNBACK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TURPENTINE.json
+++ b/inst/extdata/OSD/T/TURPENTINE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TURPIN.json
+++ b/inst/extdata/OSD/T/TURPIN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TURRET.json
+++ b/inst/extdata/OSD/T/TURRET.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TURSON.json
+++ b/inst/extdata/OSD/T/TURSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/T/TURTON.json
+++ b/inst/extdata/OSD/T/TURTON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TWOBIT.json
+++ b/inst/extdata/OSD/T/TWOBIT.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/T/TYEE.json
+++ b/inst/extdata/OSD/T/TYEE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/U/UBAR.json
+++ b/inst/extdata/OSD/U/UBAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/U/UBLY.json
+++ b/inst/extdata/OSD/U/UBLY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/U/UDOLPHO.json
+++ b/inst/extdata/OSD/U/UDOLPHO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/U/UMBO.json
+++ b/inst/extdata/OSD/U/UMBO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
-        "drainage_overview": "somewhat poorly and moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/U/UMNAK.json
+++ b/inst/extdata/OSD/U/UMNAK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/U/UMPA.json
+++ b/inst/extdata/OSD/U/UMPA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/U/UNCOMPAHGRE.json
+++ b/inst/extdata/OSD/U/UNCOMPAHGRE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
-        "drainage_overview": "somewhat poorly to poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/U/UNITYLAKE.json
+++ b/inst/extdata/OSD/U/UNITYLAKE.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/U/URANDA.json
+++ b/inst/extdata/OSD/U/URANDA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/U/URBANA.json
+++ b/inst/extdata/OSD/U/URBANA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "well, moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/U/UTABA.json
+++ b/inst/extdata/OSD/U/UTABA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/U/UVADA.json
+++ b/inst/extdata/OSD/U/UVADA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VADER.json
+++ b/inst/extdata/OSD/V/VADER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/V/VALERIAN.json
+++ b/inst/extdata/OSD/V/VALERIAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "excessively",
         "drainage_overview": "excessively"
       }
     ]

--- a/inst/extdata/OSD/V/VALKARIA.json
+++ b/inst/extdata/OSD/V/VALKARIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/V/VALLEONO.json
+++ b/inst/extdata/OSD/V/VALLEONO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/V/VAMONT.json
+++ b/inst/extdata/OSD/V/VAMONT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/V/VANAJO.json
+++ b/inst/extdata/OSD/V/VANAJO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VANDERGRIFT.json
+++ b/inst/extdata/OSD/V/VANDERGRIFT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and somewhat poorly",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VANG.json
+++ b/inst/extdata/OSD/V/VANG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VAN_HORN.json
+++ b/inst/extdata/OSD/V/VAN_HORN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VARYSBURG.json
+++ b/inst/extdata/OSD/V/VARYSBURG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VASSAR.json
+++ b/inst/extdata/OSD/V/VASSAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VASTINE.json
+++ b/inst/extdata/OSD/V/VASTINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
-        "drainage_overview": "poorly to somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VEGA.json
+++ b/inst/extdata/OSD/V/VEGA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VELMA.json
+++ b/inst/extdata/OSD/V/VELMA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VELVET.json
+++ b/inst/extdata/OSD/V/VELVET.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VENA.json
+++ b/inst/extdata/OSD/V/VENA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/V/VENATOR.json
+++ b/inst/extdata/OSD/V/VENATOR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/V/VENEZIA.json
+++ b/inst/extdata/OSD/V/VENEZIA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/V/VERDE.json
+++ b/inst/extdata/OSD/V/VERDE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/V/VERLAND.json
+++ b/inst/extdata/OSD/V/VERLAND.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/V/VERO.json
+++ b/inst/extdata/OSD/V/VERO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VERTINE.json
+++ b/inst/extdata/OSD/V/VERTINE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/V/VESTABURG.json
+++ b/inst/extdata/OSD/V/VESTABURG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VESTON.json
+++ b/inst/extdata/OSD/V/VESTON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/V/VEYO.json
+++ b/inst/extdata/OSD/V/VEYO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/V/VICI.json
+++ b/inst/extdata/OSD/V/VICI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat excessively",
         "drainage_overview": "excessively"
       }
     ]

--- a/inst/extdata/OSD/V/VICU.json
+++ b/inst/extdata/OSD/V/VICU.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/V/VIDAURI.json
+++ b/inst/extdata/OSD/V/VIDAURI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
-        "drainage_overview": "somewhat poorly to poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VIDRINE.json
+++ b/inst/extdata/OSD/V/VIDRINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VINCENT.json
+++ b/inst/extdata/OSD/V/VINCENT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/V/VININI.json
+++ b/inst/extdata/OSD/V/VININI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/V/VINJE.json
+++ b/inst/extdata/OSD/V/VINJE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VIXEN.json
+++ b/inst/extdata/OSD/V/VIXEN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VIZCAYA.json
+++ b/inst/extdata/OSD/V/VIZCAYA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "very poorly"
       }
     ]

--- a/inst/extdata/OSD/V/VLY.json
+++ b/inst/extdata/OSD/V/VLY.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well"
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VOGEL.json
+++ b/inst/extdata/OSD/V/VOGEL.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VOLKMAR.json
+++ b/inst/extdata/OSD/V/VOLKMAR.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": ""
+        "drainage_overview": "moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VOLTAIRE.json
+++ b/inst/extdata/OSD/V/VOLTAIRE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VONA.json
+++ b/inst/extdata/OSD/V/VONA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/V/VONALEE.json
+++ b/inst/extdata/OSD/V/VONALEE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/V/VORHEES.json
+++ b/inst/extdata/OSD/V/VORHEES.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WABANICA.json
+++ b/inst/extdata/OSD/W/WABANICA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WABASH.json
+++ b/inst/extdata/OSD/W/WABASH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WABASHA.json
+++ b/inst/extdata/OSD/W/WABASHA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WABASSO.json
+++ b/inst/extdata/OSD/W/WABASSO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WABUN.json
+++ b/inst/extdata/OSD/W/WABUN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WACA.json
+++ b/inst/extdata/OSD/W/WACA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WADLEY.json
+++ b/inst/extdata/OSD/W/WADLEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WAHEE.json
+++ b/inst/extdata/OSD/W/WAHEE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/W/WAHTIGUP.json
+++ b/inst/extdata/OSD/W/WAHTIGUP.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/W/WAKELEY.json
+++ b/inst/extdata/OSD/W/WAKELEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WALDEN.json
+++ b/inst/extdata/OSD/W/WALDEN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/W/WALFORD.json
+++ b/inst/extdata/OSD/W/WALFORD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WALKE.json
+++ b/inst/extdata/OSD/W/WALKE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WALLER.json
+++ b/inst/extdata/OSD/W/WALLER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/W/WALLULA.json
+++ b/inst/extdata/OSD/W/WALLULA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/W/WALSH.json
+++ b/inst/extdata/OSD/W/WALSH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WALVAN.json
+++ b/inst/extdata/OSD/W/WALVAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WAMIC.json
+++ b/inst/extdata/OSD/W/WAMIC.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WANBLEE.json
+++ b/inst/extdata/OSD/W/WANBLEE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WANETTA.json
+++ b/inst/extdata/OSD/W/WANETTA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/W/WANILLA.json
+++ b/inst/extdata/OSD/W/WANILLA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to moderately well",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WAPINITIA.json
+++ b/inst/extdata/OSD/W/WAPINITIA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WAPSHILLA.json
+++ b/inst/extdata/OSD/W/WAPSHILLA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WARBA.json
+++ b/inst/extdata/OSD/W/WARBA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
-        "drainage_overview": "moderately well and well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WARE.json
+++ b/inst/extdata/OSD/W/WARE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WAREHAM.json
+++ b/inst/extdata/OSD/W/WAREHAM.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and somewhat poorly",
-        "drainage_overview": "poorly and somewhat poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WARFIELD.json
+++ b/inst/extdata/OSD/W/WARFIELD.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WARMAN.json
+++ b/inst/extdata/OSD/W/WARMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WARNE.json
+++ b/inst/extdata/OSD/W/WARNE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "somewhat poorly",
         "drainage_overview": "somewhat poorly"
       }
     ]

--- a/inst/extdata/OSD/W/WATERDOG.json
+++ b/inst/extdata/OSD/W/WATERDOG.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "very poorly",
-        "drainage_overview": "very poorly to poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WATERFALL.json
+++ b/inst/extdata/OSD/W/WATERFALL.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well or moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WATO.json
+++ b/inst/extdata/OSD/W/WATO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WAUCEDAH.json
+++ b/inst/extdata/OSD/W/WAUCEDAH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WAUCHULA.json
+++ b/inst/extdata/OSD/W/WAUCHULA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly or very poorly",
-        "drainage_overview": "very poorly or poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WAUKENA.json
+++ b/inst/extdata/OSD/W/WAUKENA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to somewhat poorly",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/W/WAUSEON.json
+++ b/inst/extdata/OSD/W/WAUSEON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WAUTOMA.json
+++ b/inst/extdata/OSD/W/WAUTOMA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WAVELAND.json
+++ b/inst/extdata/OSD/W/WAVELAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly and poorly",
-        "drainage_overview": "very poorly and poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WAYLAND.json
+++ b/inst/extdata/OSD/W/WAYLAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WEATHERFORD.json
+++ b/inst/extdata/OSD/W/WEATHERFORD.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WEBBGULCH.json
+++ b/inst/extdata/OSD/W/WEBBGULCH.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WEBBRIDGE.json
+++ b/inst/extdata/OSD/W/WEBBRIDGE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WEEDING.json
+++ b/inst/extdata/OSD/W/WEEDING.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly and moderately well",
+        "drainage": "moderately well, somewhat poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/W/WEHADKEE.json
+++ b/inst/extdata/OSD/W/WEHADKEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WEKIVA.json
+++ b/inst/extdata/OSD/W/WEKIVA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WELBY.json
+++ b/inst/extdata/OSD/W/WELBY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WELCH.json
+++ b/inst/extdata/OSD/W/WELCH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WELLSBORO.json
+++ b/inst/extdata/OSD/W/WELLSBORO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "moderately well",
-        "drainage_overview": "moderately well and somewhat poorly"
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WENAS.json
+++ b/inst/extdata/OSD/W/WENAS.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly or poorly",
-        "drainage_overview": "somewhat poorly and poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WENDOVER.json
+++ b/inst/extdata/OSD/W/WENDOVER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WENTWORTH.json
+++ b/inst/extdata/OSD/W/WENTWORTH.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WEQUETEQUOCK.json
+++ b/inst/extdata/OSD/W/WEQUETEQUOCK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WESO.json
+++ b/inst/extdata/OSD/W/WESO.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WESSEL.json
+++ b/inst/extdata/OSD/W/WESSEL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/W/WESSER.json
+++ b/inst/extdata/OSD/W/WESSER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WESTBAY.json
+++ b/inst/extdata/OSD/W/WESTBAY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WESTLAND.json
+++ b/inst/extdata/OSD/W/WESTLAND.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WESTPLAIN.json
+++ b/inst/extdata/OSD/W/WESTPLAIN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly to somewhat poorly",
+        "drainage": "somewhat poorly, poorly",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/W/WESTSHORE.json
+++ b/inst/extdata/OSD/W/WESTSHORE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WESTVILLE.json
+++ b/inst/extdata/OSD/W/WESTVILLE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WETBAG.json
+++ b/inst/extdata/OSD/W/WETBAG.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WHEATLEY.json
+++ b/inst/extdata/OSD/W/WHEATLEY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WHETSTONE.json
+++ b/inst/extdata/OSD/W/WHETSTONE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WHITEPOST.json
+++ b/inst/extdata/OSD/W/WHITEPOST.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WHITESON.json
+++ b/inst/extdata/OSD/W/WHITESON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to poorly",
-        "drainage_overview": "somewhat poorly to poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WHITEWOOD.json
+++ b/inst/extdata/OSD/W/WHITEWOOD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "poorly"
+        "drainage": "somewhat poorly, poorly",
+        "drainage_overview": "somewhat poorly, poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WHITEWRIGHT.json
+++ b/inst/extdata/OSD/W/WHITEWRIGHT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WIBAUX.json
+++ b/inst/extdata/OSD/W/WIBAUX.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
+        "drainage": "somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WICHITA.json
+++ b/inst/extdata/OSD/W/WICHITA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WICKFORD.json
+++ b/inst/extdata/OSD/W/WICKFORD.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "subaqueous",
+        "drainage_overview": "subaqueous"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WILDMAD.json
+++ b/inst/extdata/OSD/W/WILDMAD.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WILHITE.json
+++ b/inst/extdata/OSD/W/WILHITE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WILLIS.json
+++ b/inst/extdata/OSD/W/WILLIS.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WILLOWS.json
+++ b/inst/extdata/OSD/W/WILLOWS.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "poorly",
-        "drainage_overview": "poorly to very poorly"
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WILLOW_CREEK.json
+++ b/inst/extdata/OSD/W/WILLOW_CREEK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WILSON.json
+++ b/inst/extdata/OSD/W/WILSON.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/W/WILSONGULCH.json
+++ b/inst/extdata/OSD/W/WILSONGULCH.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WINDMILL.json
+++ b/inst/extdata/OSD/W/WINDMILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WINDOWPEAK.json
+++ b/inst/extdata/OSD/W/WINDOWPEAK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or somewhat excessively",
-        "drainage_overview": "well or somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WINDTHORST.json
+++ b/inst/extdata/OSD/W/WINDTHORST.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "moderately well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/W/WIND_RIVER.json
+++ b/inst/extdata/OSD/W/WIND_RIVER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WINEG.json
+++ b/inst/extdata/OSD/W/WINEG.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WINKLEMAN.json
+++ b/inst/extdata/OSD/W/WINKLEMAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/W/WINNEBAGO.json
+++ b/inst/extdata/OSD/W/WINNEBAGO.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": "well and moderately well"
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WINNEMUCCA.json
+++ b/inst/extdata/OSD/W/WINNEMUCCA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WISE.json
+++ b/inst/extdata/OSD/W/WISE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WISHEYLU.json
+++ b/inst/extdata/OSD/W/WISHEYLU.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/W/WITBECK.json
+++ b/inst/extdata/OSD/W/WITBECK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/W/WOLF_POINT.json
+++ b/inst/extdata/OSD/W/WOLF_POINT.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WOLOT.json
+++ b/inst/extdata/OSD/W/WOLOT.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WOLVERINE.json
+++ b/inst/extdata/OSD/W/WOLVERINE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "excessively or somewhat excessively",
-        "drainage_overview": "excessively or somewhat excessively"
+        "drainage": "excessively, somewhat excessively",
+        "drainage_overview": "excessively, somewhat excessively"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WONDER.json
+++ b/inst/extdata/OSD/W/WONDER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WONDER.json
+++ b/inst/extdata/OSD/W/WONDER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WOODHURST.json
+++ b/inst/extdata/OSD/W/WOODHURST.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WOODLY.json
+++ b/inst/extdata/OSD/W/WOODLY.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WOODROCK.json
+++ b/inst/extdata/OSD/W/WOODROCK.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WOODROW.json
+++ b/inst/extdata/OSD/W/WOODROW.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WOODSLAKE.json
+++ b/inst/extdata/OSD/W/WOODSLAKE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WOOLPER.json
+++ b/inst/extdata/OSD/W/WOOLPER.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WORTHING.json
+++ b/inst/extdata/OSD/W/WORTHING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WORTMAN.json
+++ b/inst/extdata/OSD/W/WORTMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well or moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WOVER.json
+++ b/inst/extdata/OSD/W/WOVER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
-        "drainage_overview": "poorly and very poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WRENTHAM.json
+++ b/inst/extdata/OSD/W/WRENTHAM.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WRIGHTMAN.json
+++ b/inst/extdata/OSD/W/WRIGHTMAN.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WULIE.json
+++ b/inst/extdata/OSD/W/WULIE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/W/WUNJEY.json
+++ b/inst/extdata/OSD/W/WUNJEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well to well",
+        "drainage": "well, moderately well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/W/WURTSBORO.json
+++ b/inst/extdata/OSD/W/WURTSBORO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "moderately well"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/W/WYASKET.json
+++ b/inst/extdata/OSD/W/WYASKET.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "poorly and very poorly",
+        "drainage": "poorly, very poorly",
         "drainage_overview": "poorly"
       }
     ]

--- a/inst/extdata/OSD/W/WYETH.json
+++ b/inst/extdata/OSD/W/WYETH.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/X/XAVIER.json
+++ b/inst/extdata/OSD/X/XAVIER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/Y/YAKI.json
+++ b/inst/extdata/OSD/Y/YAKI.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Y/YAKIMA.json
+++ b/inst/extdata/OSD/Y/YAKIMA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Y/YALLANI.json
+++ b/inst/extdata/OSD/Y/YALLANI.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Y/YAMHILL.json
+++ b/inst/extdata/OSD/Y/YAMHILL.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/Y/YANCEYVILLE.json
+++ b/inst/extdata/OSD/Y/YANCEYVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "well",
+        "drainage": "excessively, somewhat excessively, well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Y/YANKEE.json
+++ b/inst/extdata/OSD/Y/YANKEE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Y/YARDLEY.json
+++ b/inst/extdata/OSD/Y/YARDLEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": ""
       }
     ]

--- a/inst/extdata/OSD/Y/YAUPON.json
+++ b/inst/extdata/OSD/Y/YAUPON.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly to moderately well",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/Y/YAWKEY.json
+++ b/inst/extdata/OSD/Y/YAWKEY.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Y/YEATES_HOLLOW.json
+++ b/inst/extdata/OSD/Y/YEATES_HOLLOW.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well and moderately well",
-        "drainage_overview": "well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Y/YELLOWBOTTOM.json
+++ b/inst/extdata/OSD/Y/YELLOWBOTTOM.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Y/YODER.json
+++ b/inst/extdata/OSD/Y/YODER.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well to somewhat excessively",
-        "drainage_overview": "well to somewhat excessively"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Y/YORBA.json
+++ b/inst/extdata/OSD/Y/YORBA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Y/YORKVILLE.json
+++ b/inst/extdata/OSD/Y/YORKVILLE.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well and well",
+        "drainage": "well, moderately well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Y/YRIBARREN.json
+++ b/inst/extdata/OSD/Y/YRIBARREN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Y/YUBA.json
+++ b/inst/extdata/OSD/Y/YUBA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "moderately well"
       }
     ]

--- a/inst/extdata/OSD/Z/ZAAR.json
+++ b/inst/extdata/OSD/Z/ZAAR.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "somewhat poorly",
-        "drainage_overview": "somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/Z/ZACA.json
+++ b/inst/extdata/OSD/Z/ZACA.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Z/ZAMORA.json
+++ b/inst/extdata/OSD/Z/ZAMORA.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Z/ZAPADNI.json
+++ b/inst/extdata/OSD/Z/ZAPADNI.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Z/ZEEBAR.json
+++ b/inst/extdata/OSD/Z/ZEEBAR.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Z/ZEESIX.json
+++ b/inst/extdata/OSD/Z/ZEESIX.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Z/ZENIFF.json
+++ b/inst/extdata/OSD/Z/ZENIFF.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Z/ZIA.json
+++ b/inst/extdata/OSD/Z/ZIA.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "well",
-        "drainage_overview": "well"
+        "drainage": "somewhat excessively, well",
+        "drainage_overview": "somewhat excessively, well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Z/ZING.json
+++ b/inst/extdata/OSD/Z/ZING.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well or somewhat poorly",
-        "drainage_overview": "moderately well or somewhat poorly"
+        "drainage": "moderately well, somewhat poorly",
+        "drainage_overview": "moderately well, somewhat poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/Z/ZIPP.json
+++ b/inst/extdata/OSD/Z/ZIPP.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/Z/ZOATE.json
+++ b/inst/extdata/OSD/Z/ZOATE.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "",
-        "drainage_overview": ""
+        "drainage": "well",
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Z/ZOLOTOI.json
+++ b/inst/extdata/OSD/Z/ZOLOTOI.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Z/ZOOK.json
+++ b/inst/extdata/OSD/Z/ZOOK.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "very poorly",
-        "drainage_overview": "poorly"
+        "drainage": "poorly, very poorly",
+        "drainage_overview": "poorly, very poorly"
       }
     ]
   ],

--- a/inst/extdata/OSD/Z/ZUKAN.json
+++ b/inst/extdata/OSD/Z/ZUKAN.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Z/ZUMBRO.json
+++ b/inst/extdata/OSD/Z/ZUMBRO.json
@@ -64,8 +64,8 @@
   "SITE": [
     [
       {
-        "drainage": "moderately well",
-        "drainage_overview": "well and moderately well"
+        "drainage": "well, moderately well",
+        "drainage_overview": "well, moderately well"
       }
     ]
   ],

--- a/inst/extdata/OSD/Z/ZUNKER.json
+++ b/inst/extdata/OSD/Z/ZUNKER.json
@@ -64,7 +64,7 @@
   "SITE": [
     [
       {
-        "drainage": "",
+        "drainage": "well",
         "drainage_overview": "well"
       }
     ]

--- a/inst/extdata/OSD/Z/ZYPLAR.json
+++ b/inst/extdata/OSD/Z/ZYPLAR.json
@@ -65,7 +65,7 @@
     [
       {
         "drainage": "well",
-        "drainage_overview": ""
+        "drainage_overview": "well"
       }
     ]
   ],

--- a/man/create_OSD.Rd
+++ b/man/create_OSD.Rd
@@ -4,10 +4,12 @@
 \alias{create_OSD}
 \title{Create OSD Dataset}
 \usage{
-create_OSD(...)
+create_OSD(..., download = TRUE)
 }
 \arguments{
 \item{...}{not used}
+
+\item{download}{_logical_. Download OSD Snapshot from OSDRegistry? Default: `TRUE`}
 }
 \value{
 TRUE if successful


### PR DESCRIPTION
Incremental fixes: 
- Generalize drainage class pattern: current "first" matching misses a lot of cases with the word "drained" twice (n=604 series affected; previously single class became multi class)
- Order (excessively -> very poorly) and interpolate between series ranges that span two or more classes (n=1306 series)
- Fix parsing of subaqueous drainage class (n=69 series)
- Fix parsing of hyphenated drainage class (n=792 series)
- Fix list-style Drainage and Permeability sections (i.e. `"Drainage: well"` or `Drainage class: somewhat poorly`) (n=269 series)