### PR TITLE
fix: parsing for neutral hues with null chroma

### DIFF
--- a/R/parseOSD_functions.R
+++ b/R/parseOSD_functions.R
@@ -374,11 +374,11 @@
   # interpretation is tough when multiple colors / hz are given
   # single rule, with dry/moist state
   # note that dry/moist may not always be present
-  color.rule <- "\\(([Ol0-9]?[\\.]?[Ol0-9]?[B|G|Y|R|N]+)([ ]+?[Ol0-9\\.]+)/([Ol0-9])\\)\\s?(dry|moist|)"
+  color.rule <- "\\(([Ol0-9]?[\\.]?[Ol0-9]?[B|G|Y|R|N]+)([ ]+?[Ol0-9\\.]+)/([Ol0-9]*)\\)\\s?(dry|moist|)"
 
   # detect moist and dry colors
-  dry.color.rule <- "\\(([Ol0-9]?[\\.]?[Ol0-9]?[B|G|Y|R|N]+)([ ]+?[Ol0-9\\.]+)/([Ol0-9])\\)(?! moist)"
-  moist.color.rule <- "\\(([Ol0-9]?[\\.]?[Ol0-9]?[B|G|Y|R|N]+)([ ]+?[Ol0-9\\.]+)/(Ol0-9])\\) moist"
+  dry.color.rule <- "\\(([Ol0-9]?[\\.]?[Ol0-9]?[B|G|Y|R|N]+)([ ]+?[Ol0-9\\.]+)/([Ol0-9]*)\\)(?! moist)"
+  moist.color.rule <- "\\(([Ol0-9]?[\\.]?[Ol0-9]?[B|G|Y|R|N]+)([ ]+?[Ol0-9\\.]+)/([Ol0-9]*)\\) moist"
 
   # ID actual lines of horizon information
   hz.idx <- unique(c(grep(hz.rule, tp), grep(hz.rule.no.bottom, tp)))


### PR DESCRIPTION
This PR makes the chroma part of the color optional so that instead of NA hue, value, and chroma, the hue and value are returned for OSD with color described like ``"(N 4/)"`