### PR TITLE
Fix horizon designations containing `"and"`

### DIFF
--- a/R/create_OSD.R
+++ b/R/create_OSD.R
@@ -406,8 +406,6 @@ osd_to_json <- function(logfile = file.path(output_dir, "OSD/OSD.log"),
 
     fn <- gsub("\\.txt", "\\.json", basename(all_osds[[i]]))
 
-    # note: all-NA columns are silently dropped by toJSON
-    # https://github.com/ncss-tech/SoilKnowledgeBase/issues/35
     write(jsonlite::toJSON(x, pretty = TRUE, auto_unbox = TRUE, na = 'string'), file = file.path(fld, fn))
     return(TRUE)
   })

--- a/R/parseOSD_functions.R
+++ b/R/parseOSD_functions.R
@@ -331,10 +331,10 @@
   # https://github.com/ncss-tech/SoilKnowledgeBase/issues/64
 
   # detect horizons with both top and bottom depths
-  hz.rule <-            "([\\^\\'\\/a-zA-Z0-9]+)\\s*[-=\u2014]+\\s*([Ol0-9.]+)\\s*?(to|-)?\\s+?([Ol0-9.]+)\\s*?(in|inches|cm|centimeters)"
+  hz.rule <- "([\\^\\'\\/a-zA-Z0-9]+(?: and [\\^\\'\\/a-zA-Z0-9]+)?)\\s*[-=\u2014]+\\s*([Ol0-9.]+)\\s*?(to|-)?\\s+?([Ol0-9.]+)\\s*?(in|inches|cm|centimeters)"
 
   # detect horizons with no bottom depth
-  hz.rule.no.bottom <- "([\\^\\'\\/a-zA-Z0-9]+)\\s*[-=\u2014]+?\\s*([Ol0-9.]+)\\s*(to|-)?\\s*([Ol0-9.]+)?\\s*?(in|inches|cm|centimeters)"
+  hz.rule.no.bottom <- "([\\^\\'\\/a-zA-Z0-9]+(?: and [\\^\\'\\/a-zA-Z0-9]+)?)\\s*[-=\u2014]+?\\s*([Ol0-9.]+)\\s*(to|-)?\\s*([Ol0-9.]+)?\\s*?(in|inches|cm|centimeters)"
 
   ## TODO: toggle dry/moist assumption:
   ##


### PR DESCRIPTION
This uses an optional non-capturing group to parse combination horizon designations using the "and" style e.g. `"E and Bt1"` to close the last TODO item from #25 